### PR TITLE
Import gds cells directly

### DIFF
--- a/ubcpdk/components/cells.py
+++ b/ubcpdk/components/cells.py
@@ -8,49 +8,59 @@ def y_splitter() -> Component:
 import gdsfactory as gf
 from gdsfactory.add_pins import add_pins_bbox_siepic
 
-from ubcpdk.import_gds import import_gds_siepic_pins
+from ubcpdk.import_gds import import_gds
 from ubcpdk.tech import strip, LAYER_STACK, LAYER
 from ubcpdk.components.straight import straight
 
 
 dc_broadband_te = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_bdc_te1550.gds",
+    name="ebeam_bdc_te1550",
+    model="ebeam_bdc_te1550",
     doc="Broadband directional coupler TE1550 50/50 power.",
 )
 
 dc_broadband_tm = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_bdc_tm1550.gds",
+    name="ebeam_bdc_tm1550",
+    model="ebeam_bdc_tm1550",
     doc="Broadband directional coupler TM1550 50/50 power.",
 )
 
 dc_adiabatic = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_adiabatic_te1550.gds",
+    name="ebeam_adiabatic_te1550",
+    model="ebeam_adiabatic_te1550",
     doc="Adiabatic directional coupler TE1550 50/50 power.",
 )
 
 y_adiabatic = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_y_adiabatic.gds",
-    doc="Adiabatic Y junction TE1550 50/50 power.",
     name="ebeam_y_adiabatic",
+    model="ebeam_y_adiabatic",
+    doc="Adiabatic Y junction TE1550 50/50 power.",
 )
 
 y_splitter = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_y_1550.gds",
     doc="Y junction TE1550 50/50 power.",
     name="ebeam_y_1550",
     model="ebeam_y_1550",
-    opt1="opt_a1",
-    opt2="opt_b1",
-    opt3="opt_b2",
+    layout_model_port_pairs=(
+        ("opt1", "opt_a1"),
+        ("opt2", "opt_b1"),
+        ("opt3", "opt_b2")
+        )
 )
 crossing = gf.partial(
-    import_gds_siepic_pins,
+    import_gds,
     "ebeam_crossing4.gds",
+    model="ebeam_crossing4",
     doc="TE waveguide crossing.",
 )
 

--- a/ubcpdk/components/grating_couplers.py
+++ b/ubcpdk/components/grating_couplers.py
@@ -1,56 +1,62 @@
 import gdsfactory as gf
 from ubcpdk.import_gds import (
-    add_ports_renamed_gratings,
-    add_ports_siepic_gratings,
-    import_gds_siepic_pins,
+    import_gds
 )
 
 
-# This rotation is causing issues in interconnect
-add_ports_rotate180 = gf.compose(gf.functions.rotate180, add_ports_renamed_gratings)
-add_ports_rotate180_siepic = gf.compose(
-    gf.functions.rotate180, add_ports_siepic_gratings
+import_gc = gf.compose(
+    gf.functions.rotate180,
+    import_gds,
 )
 
-import_gc = gf.partial(
-    import_gds_siepic_pins,
-    decorator=add_ports_rotate180,
-)
-
-import_gc_interconnect = gf.partial(
-    import_gds_siepic_pins,
-    decorator=add_ports_rotate180_siepic,
-)
 
 gc_te1550 = gf.partial(
-    import_gc_interconnect,
+    import_gc,
     "ebeam_gc_te1550.gds",
     polarization="te",
     wavelength=1.55,
     model="ebeam_gc_te1550",
-    opt1="opt_wg",
+    name="ebeam_gc_te1550",
+    layout_model_port_pairs=(
+        ("opt1", "opt_wg"),
+        )
 )
 
 gc_te1550_broadband = gf.partial(
     import_gc,
     "ebeam_gc_te1550_broadband.gds",
+    name="ebeam_gc_te1550_broadband",
+    model="ebeam_gc_te1550_broadband",
     polarization="te",
     wavelength=1.55,
+    layout_model_port_pairs=(
+        ("opt1", "opt_wg"),
+        )
 )
 
 
 gc_te1310 = gf.partial(
     import_gc,
     "ebeam_gc_te1310.gds",
+    name="ebeam_gc_te1310",
+    model="ebeam_gc_te1310",
     polarization="te",
     wavelength=1.31,
+    layout_model_port_pairs=(
+        ("opt1", "opt_wg"),
+        )
 )
 
 gc_tm1550 = gf.partial(
     import_gc,
     "ebeam_gc_tm1550.gds",
+    name="ebeam_gc_tm1550",
+    model="ebeam_gc_tm1550",
     polarization="tm",
     wavelength=1.55,
+    layout_model_port_pairs=(
+        ("opt1", "opt_wg"),
+        )
 )
 
 

--- a/ubcpdk/import_gds.py
+++ b/ubcpdk/import_gds.py
@@ -3,7 +3,6 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.port import Port
 from gdsfactory.types import Layer
-from gdsfactory.add_pins import add_pins_bbox_siepic
 
 from ubcpdk.tech import LAYER
 from ubcpdk.config import PATH
@@ -40,6 +39,15 @@ def remove_pins(component) -> Component:
     component.remove_layers(layers=(LAYER.DEVREC, LAYER.PORT, LAYER.PORTE))
     component.paths = []
     component._bb_valid = False
+    return component
+
+
+def remove_pins_recursive(component):
+    component = remove_pins(component)
+    if component.references:
+        for ref in component.references:
+            rcell = ref.parent
+            ref.parent = remove_pins_recursive(rcell)
     return component
 
 
@@ -170,44 +178,45 @@ def add_siepic_labels_and_simulation_info(
     return c
 
 
+import_gds = gf.partial(
+    gf.import_gds,
+    gdsdir=PATH.gds,
+    library="Design kits/ebeam",
+    decorator=add_ports_from_siepic_pins
+    )
+#
 # gratings have a 2nm square that is sticking out 1nm
-add_pins_gratings = gf.partial(add_pins_bbox_siepic, padding=-1e-3)
-
-add_ports_renamed = gf.compose(
-    add_pins_bbox_siepic, gf.port.auto_rename_ports, remove_pins, add_ports
-)
-add_ports_renamed_gratings = gf.compose(
-    add_pins_gratings, gf.port.auto_rename_ports, remove_pins, add_ports
-)
-
-import_gds = gf.partial(gf.import_gds, gdsdir=PATH.gds, decorator=add_ports_renamed)
-
-add_ports_siepic = gf.compose(
-    add_siepic_labels_and_simulation_info,
-    add_pins_bbox_siepic,
-    remove_pins,
-    add_ports_from_siepic_pins,
-)
-
-add_ports_siepic_gratings = gf.compose(
-    add_siepic_labels_and_simulation_info,
-    add_pins_gratings,
-    remove_pins,
-    add_ports_from_siepic_pins,
-)
-
-import_gds_siepic_pins = gf.partial(
-    gf.import_gds, gdsdir=PATH.gds, decorator=add_ports_siepic
-)
-
-import_gds_siepic_pins_gratings = gf.partial(
-    gf.import_gds, gdsdir=PATH.gds, decorator=add_ports_siepic_gratings
-)
-
+# add_pins_gratings = gf.partial(add_pins_bbox_siepic, padding=-1e-3)
+#
+# add_ports_renamed = gf.compose(
+#     add_pins_bbox_siepic, gf.port.auto_rename_ports, remove_pins, add_ports_from_siepic_pins
+# )
+# add_ports_renamed_gratings = gf.compose(
+#     add_pins_gratings, gf.port.auto_rename_ports, remove_pins, add_ports_from_siepic_pins
+# )
+#
+# # add_ports_siepic = gf.compose(
+# #     add_pins_bbox_siepic,
+# #     remove_pins,
+# #     add_ports_from_siepic_pins,
+# # )
+# #
+# add_ports_siepic_gratings = gf.compose(
+#     add_pins_gratings,
+#     remove_pins,
+#     add_ports_from_siepic_pins,
+# )
+#
+# import_gds_siepic_pins = gf.partial(import_gds, gdsdir=PATH.gds)
+#
+# import_gds_siepic_pins_gratings = gf.partial(
+#     import_gds_siepic_pins,
+#     decorator=add_ports_siepic_gratings
+# )
 
 if __name__ == "__main__":
-    gdsname = "ebeam_crossing4.gds"
+    # gdsname = "ebeam_crossing4.gds"
     gdsname = "ebeam_y_1550.gds"
-    c = import_gds_siepic_pins(gdsname)
+    c = import_gds(gdsname)
     # print(c.ports)
     c.show(show_ports=False)


### PR DESCRIPTION
Import gds shouldn't need to delete and re-add all of the labels and pins and this PR changes it to just import the cell directly without deleting anything. This assumes that the imported gds file is already siepic-compatible and adds ports where it finds siepic pins.

Also consolidated the grating coupler methods by removing the 'interconnect' option.