### PR TITLE
fixed 'required privilege' error (1314) on windows

### DIFF
--- a/install_tech.py
+++ b/install_tech.py
@@ -15,10 +15,16 @@ dest = dest_folder / "ubcpdk"
 
 
 def make_link(src, dest):
-    if sys.platform == "win32":
-        subprocess.check_call(f"mklink /J {dest} {src}", shell=True)
-    else:
+    try:
         os.symlink(src, dest)
+    except OSError as err:
+        print("Could not create symlink!")
+        print("     Error: ", err)
+        if sys.platform == "win32":
+            print("Trying to create a junction instead of a symlink...")
+            proc = subprocess.check_call(f"mklink /J {dest} {src}", shell=True)
+            if proc != 0:
+                print("Could not create link!")
 
 
 def install_tech(src, dest):

--- a/install_tech.py
+++ b/install_tech.py
@@ -21,6 +21,7 @@ def make_link(src, dest):
         print("Could not create symlink!")
         print("     Error: ", err)
         if sys.platform == "win32":
+            # https://stackoverflow.com/questions/32877260/privlege-error-trying-to-create-symlink-using-python-on-windows-10
             print("Trying to create a junction instead of a symlink...")
             proc = subprocess.check_call(f"mklink /J {dest} {src}", shell=True)
             if proc != 0:

--- a/install_tech.py
+++ b/install_tech.py
@@ -57,7 +57,7 @@ def install_drc(src, dest):
         os.remove(dest)
         make_link(src, dest)
 
-    print(f"layermap installed to {dest}")
+    print(f"drc installed to {dest}")
 
 
 if __name__ == "__main__":

--- a/install_tech.py
+++ b/install_tech.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import sys
+import subprocess
 
 klayout_folder = "KLayout" if sys.platform == "win32" else ".klayout"
 cwd = pathlib.Path(__file__).resolve().parent
@@ -13,6 +14,13 @@ dest_folder.mkdir(exist_ok=True, parents=True)
 dest = dest_folder / "ubcpdk"
 
 
+def make_link(src, dest):
+    if sys.platform == "win32":
+        subprocess.check_call(f"mklink /J {dest} {src}", shell=True)
+    else:
+        os.symlink(src, dest)
+
+
 def install_tech(src, dest):
     """Installs tech."""
     if dest.exists():
@@ -20,10 +28,11 @@ def install_tech(src, dest):
         return
 
     try:
-        os.symlink(src, dest)
+        make_link(src, dest)
     except Exception:
         os.remove(dest)
-        os.symlink(src, dest)
+        make_link(src, dest)
+
     print(f"layermap installed to {dest}")
 
 
@@ -36,10 +45,11 @@ def install_drc(src, dest):
     dest_folder = dest.parent
     dest_folder.mkdir(exist_ok=True, parents=True)
     try:
-        os.symlink(src, dest)
+        make_link(src, dest)
     except Exception:
         os.remove(dest)
-        os.symlink(src, dest)
+        make_link(src, dest)
+
     print(f"layermap installed to {dest}")
 
 


### PR DESCRIPTION
On running instal_tech.py, the following error was occuring due to permissions issues with the os.symlink method:

_OSError: [WinError 1314] A required privilege is not held by the client_

Using subprocess.check_call creates a "junction" rather than a symlink and fixes this error. 