### PR TITLE
add install, pre-commit, and release instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,17 @@ make pre-commit
 
 ## Release
 
-Releases are automated via GitHub Actions.
+1. Update the changelog in `.changelog.d/` with entries describing the changes. Make sure the changelog is clear and readable for customers.
+2. Bump the version:
 
-1. Merge your changes to `main`.
-2. A draft release is automatically created/updated by the release drafter.
-3. When ready, publish the draft release with a tag (e.g. `v1.0.0`). This triggers the release workflow that builds wheels and uploads them.
+```bash
+tbump 0.0.1
+```
+
+3. Push the tag:
+
+```bash
+git push --tags
+```
+
+4. Create a pull request with the updated changelog and version bump. This triggers the release workflow that builds wheels and uploads them.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,17 @@ uv sync --extra docs --extra dev
 - [gdsfactory docs](https://gdsfactory.github.io/gdsfactory/)
 - [UBCpdk docs](https://gdsfactory.github.io/ubc/) and [code](https://github.com/gdsfactory/ubc)
 - [ubc1](https://github.com/gdsfactory/ubc1)
+
+## Pre-commit
+
+```bash
+make pre-commit
+```
+
+## Release
+
+Releases are automated via GitHub Actions.
+
+1. Merge your changes to `main`.
+2. A draft release is automatically created/updated by the release drafter.
+3. When ready, publish the draft release with a tag (e.g. `v1.0.0`). This triggers the release workflow that builds wheels and uploads them.

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ make pre-commit
 
 ## Release
 
-1. Update the changelog in `.changelog.d/` with entries describing the changes. Make sure the changelog is clear and readable for customers.
-2. Bump the version:
+1. Bump the version:
 
 ```bash
 tbump 0.0.1
 ```
 
-3. Push the tag:
+2. Push the tag:
 
 ```bash
 git push --tags
 ```
+This triggers the release workflow that builds wheels and uploads them.
 
-4. Create a pull request with the updated changelog and version bump. This triggers the release workflow that builds wheels and uploads them.
+3. Create a pull request with the updated changelog since last release.


### PR DESCRIPTION
## Summary
- Add installation, pre-commit, and release instructions to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document pre-commit usage and release workflow in the project README.

Documentation:
- Add README section describing how to run pre-commit checks via make.
- Add README section outlining the automated GitHub Actions release process and steps to publish a release.