### PR TITLE
security: pin runtime and build deps to exact versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.39.0",
-  "gplugins[sax,tidy3d]~=2.0.0",
-  "jsondiff",
-  "doroutes>=0.3.0",
-  "gdsfactoryplus",
-  "pytz"
+  "gdsfactory==9.39.3",
+  "gplugins[sax,tidy3d]==2.0.1",
+  "jsondiff==2.2.1",
+  "doroutes==0.4.0",
+  "gdsfactoryplus==1.7.0",
+  "pytz==2026.1.post1"
 ]
 description = "ubcpdk pdk"
 keywords = ["python"]


### PR DESCRIPTION
## Summary
- Hard-pin all runtime dependencies and build-system requires to exact versions to mitigate dependency confusion / supply chain attacks
- Dev dependencies left with floor pins (not a runtime attack surface)

## Recommendation
This is a security patch — recommend cutting a new release after merge so downstream consumers pick up the pinned deps.

## Test plan
- [ ] `uv lock` resolves cleanly
- [ ] `uv sync --dev` installs successfully
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)