### PR TITLE
fix: pass GFP_API_KEY to docs CI and update meep notebook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,3 +13,5 @@ permissions:
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/docs/notebooks/meep_ybranch.ipynb
+++ b/docs/notebooks/meep_ybranch.ipynb
@@ -64,7 +64,7 @@
     "sim.monitors = [\"o1\", \"o2\", \"o3\"]\n",
     "sim.domain(pml=1.0, margin=0.5)\n",
     "sim.solver(resolution=20, simplify_tol=0.01, save_animation=True, verbose_interval=5.0)\n",
-    "sim.solver.stop_after_sources(time=60)\n",
+    "sim.solver.stop_when_energy_decayed()\n",
     "\n",
     "print(sim.validate_config())"
    ]


### PR DESCRIPTION
## Summary
- Restore `GFP_API_KEY` secret forwarding to the reusable docs workflow — it was dropped in 734e9f1 when CI was centralized, causing gsim 401 errors
- Update `meep_ybranch.ipynb` to use `stop_when_energy_decayed()` instead of `stop_after_sources(time=60)`

## Summary by Sourcery

Restore docs CI secret forwarding and update Meep Y-branch notebook stopping condition.

Bug Fixes:
- Pass GFP_API_KEY secret through the reusable docs pages workflow to fix failing authenticated docs builds.

Documentation:
- Update the meep_ybranch notebook to use the energy-decay-based solver stopping condition instead of a fixed-time stop.