### PR TITLE
ci: add metric badge workflows and README dashboard

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -1,0 +1,36 @@
+name: Model Coverage
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  model-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - run: make install
+      - name: Check model coverage
+        env:
+          GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+        run: |
+          uv run python -c "
+          import importlib, os
+          mod = importlib.import_module('ubcpdk')
+          pdk = mod.PDK
+          pdk.activate()
+          cells = pdk.cells
+          models = getattr(pdk, 'models', {}) or {}
+          total = len(cells)
+          with_model = len(set(cells) & set(models))
+          pct = (with_model / total * 100) if total else 0
+          summary = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          with open(summary, 'a') as f:
+              f.write(f'## Model Coverage\n\n')
+              f.write(f'| Metric | Value |\n|--------|-------|\n')
+              f.write(f'| Cells | {total} |\n')
+              f.write(f'| Cells with model | {with_model} |\n')
+              f.write(f'| Coverage | {pct:.1f}% |\n')
+          print(f'Model coverage: {with_model}/{total} ({pct:.1f}%)')
+          "

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -1,0 +1,25 @@
+name: Model Regression
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  model-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - run: make install
+      - name: Run model regression tests
+        run: |
+          output=$(make test 2>&1) && exit 0
+          if echo "$output" | grep -qE '/ 0 selected|no tests ran'; then
+            echo "No model tests found — skipping"
+            exit 0
+          fi
+          echo "$output"
+          exit 1
+        env:
+          GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+          PYTEST_ADDOPTS: "-k model --tb=short"

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,33 @@
+name: Test Coverage
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - run: make install
+      - name: Run tests with coverage
+        run: make test
+        env:
+          GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+          PYTEST_ADDOPTS: "--cov=ubcpdk --cov-report=term-missing --cov-report=xml --cov-append -q"
+      - name: Write summary
+        if: always()
+        run: |
+          uv run python -c "
+          import xml.etree.ElementTree as ET, os
+          try:
+              tree = ET.parse('coverage.xml')
+              rate = float(tree.getroot().attrib.get('line-rate', 0)) * 100
+              summary = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+              with open(summary, 'a') as f:
+                  f.write(f'## Test Coverage\n\nLine coverage: {rate:.1f}%\n')
+              print(f'Coverage: {rate:.1f}%')
+          except Exception as e:
+              print(f'Could not parse coverage: {e}')
+          "

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -1,0 +1,131 @@
+        name: Update Badges
+        on:
+          push:
+            branches: [main]
+          schedule:
+            - cron: "0 6 * * 1"
+          workflow_dispatch:
+        permissions:
+          contents: write
+          issues: read
+          pull-requests: read
+        jobs:
+          badges:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              - run: make install
+
+              - name: Compute test coverage
+                run: make test
+                continue-on-error: true
+                env:
+                  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+                  PYTEST_ADDOPTS: "--cov=ubcpdk --cov-report=xml --cov-append -q"
+
+              - name: Generate all badges
+                env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+                run: |
+                  mkdir -p badges
+                  uv run python - <<'PYEOF'
+                  import importlib, os, subprocess, xml.etree.ElementTree as ET
+                  from pathlib import Path
+
+                  SVG_TEMPLATE = """<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="{width}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)">
+    <rect width="{label_w}" height="20" fill="#555"/>
+    <rect x="{label_w}" width="{value_w}" height="20" fill="{color}"/>
+    <rect width="{width}" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="{label_x}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+    <text x="{label_x}" y="14">{label}</text>
+    <text x="{value_x}" y="15" fill="#010101" fill-opacity=".3">{value}</text>
+    <text x="{value_x}" y="14">{value}</text>
+  </g>
+</svg>"""
+
+                  def make_badge(label, value, color, filename):
+                      label_w = len(label) * 6.5 + 12
+                      value_w = len(value) * 6.5 + 12
+                      width = label_w + value_w
+                      svg = SVG_TEMPLATE.format(
+                          width=int(width), label_w=int(label_w), value_w=int(value_w),
+                          label_x=int(label_w / 2), value_x=int(label_w + value_w / 2),
+                          color=color, label=label, value=value,
+                      )
+                      Path(f"badges/{filename}").write_text(svg)
+                      print(f"  {filename}: {label} = {value}")
+
+                  # --- Test Coverage ---
+                  try:
+                      tree = ET.parse("coverage.xml")
+                      rate = float(tree.getroot().attrib.get("line-rate", 0)) * 100
+                  except Exception:
+                      rate = 0
+                  color = "#4c1" if rate >= 80 else ("#dfb317" if rate >= 60 else "#e05d44")
+                  make_badge("coverage", f"{rate:.0f}%", color, "coverage.svg")
+
+                  # --- Model Coverage ---
+                  try:
+                      mod = importlib.import_module("ubcpdk")
+                      pdk = mod.PDK
+                      pdk.activate()
+                      cells = pdk.cells
+                      models = getattr(pdk, "models", {}) or {}
+                      total = len(cells)
+                      with_model = len(set(cells) & set(models))
+                      model_pct = (with_model / total * 100) if total else 0
+                  except Exception as e:
+                      print(f"  model coverage error: {e}")
+                      model_pct = 0
+                  color = "#4c1" if model_pct >= 80 else ("#dfb317" if model_pct >= 40 else "#e05d44")
+                  make_badge("models", f"{model_pct:.0f}%", color, "model_coverage.svg")
+
+                  # --- Open Issues & PRs ---
+                  repo = os.environ.get("GITHUB_REPOSITORY", "")
+                  def gh_count(query):
+                      try:
+                          r = subprocess.run(
+                              ["gh", "api", f"search/issues?q=repo:{repo}+{query}&per_page=1",
+                               "--jq", ".total_count"],
+                              capture_output=True, text=True, check=True,
+                          )
+                          return int(r.stdout.strip())
+                      except Exception:
+                          return 0
+
+                  open_issues = gh_count("is:issue+is:open")
+                  open_prs = gh_count("is:pr+is:open")
+                  make_badge("issues", str(open_issues), "#4c1" if open_issues == 0 else ("#dfb317" if open_issues < 10 else "#e05d44"), "issues.svg")
+                  make_badge("PRs", str(open_prs), "#4c1" if open_prs == 0 else ("#dfb317" if open_prs < 10 else "#e05d44"), "prs.svg")
+                  PYEOF
+
+              - name: Push badges to badges branch
+                run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  tmp=$(mktemp -d)
+                  cp badges/*.svg "$tmp/"
+
+                  git fetch origin badges 2>/dev/null && git checkout badges || {
+                    git checkout --orphan badges
+                    git rm -rf . 2>/dev/null || true
+                  }
+
+                  cp "$tmp"/*.svg .
+                  git add *.svg
+                  git diff --cached --quiet && echo "No badge changes" && exit 0
+                  git commit -m "Update metric badges [skip ci]"
+                  git push origin badges

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # ubcpdk (SiEPIC Ebeam PDK) 3.3.4
 
+<!-- BADGES:START -->
+[![Docs](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml)
+[![Tests](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml)
+[![DRC](https://github.com/gdsfactory/ubc/actions/workflows/drc.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/drc.yml)
+[![Model Regression](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml)
+[![Test Coverage](https://github.com/gdsfactory/ubc/raw/badges/coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_coverage.yml)
+[![Model Coverage](https://github.com/gdsfactory/ubc/raw/badges/model_coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_coverage.yml)
+[![Issues](https://github.com/gdsfactory/ubc/raw/badges/issues.svg)](https://github.com/gdsfactory/ubc/issues)
+[![PRs](https://github.com/gdsfactory/ubc/raw/badges/prs.svg)](https://github.com/gdsfactory/ubc/pulls)
+<!-- BADGES:END -->
+
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD)
 [![pypi](https://img.shields.io/pypi/v/ubcpdk)](https://pypi.org/project/ubcpdk/)
 [![mit](https://img.shields.io/github/license/gdsfactory/ubc)](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
## Summary

- Add **model_coverage.yml** workflow — reports fraction of cells that have a model
- Add **model_regression.yml** workflow — runs `pytest -k model` to catch model regressions
- Add **test_coverage.yml** workflow — runs pytest with `--cov` and reports line coverage
- Add **repo_stats.yml** workflow — weekly cron that counts open issues and PRs
- Update README with badge dashboard for all metrics (Docs, Tests, DRC, Model Coverage, Model Regression, Test Coverage, Repo Stats)

## Metrics tracked

| Badge | Source |
|-------|--------|
| Docs | Existing `pages.yml` / `docs.yml` |
| Tests | Existing `test_code.yml` |
| DRC | Existing `drc.yml` |
| Model Coverage | New `model_coverage.yml` |
| Model Regression | New `model_regression.yml` |
| Test Coverage | New `test_coverage.yml` |
| Repo Stats | New `repo_stats.yml` |

## Summary by Sourcery

Add CI workflows to track testing, model, and repository health metrics and expose them via badges in the README.

New Features:
- Introduce GitHub Actions workflows for test coverage, model coverage, model regression checks, and repository statistics reporting.

CI:
- Add test_coverage workflow to run pytest with coverage and publish coverage summaries.
- Add model_coverage workflow to compute and summarize the fraction of cells with models.
- Add model_regression workflow to run model-focused pytest suites on pushes and pull requests.
- Add repo_stats workflow to periodically report open issue and pull request counts.

Documentation:
- Add a README badge dashboard surfacing documentation, tests, DRC, model coverage, model regression, test coverage, and repo statistics statuses.