### PR TITLE
ci: add metric badge workflows and README dashboard

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -1,0 +1,11 @@
+name: Model Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
+    secrets: inherit

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -1,0 +1,11 @@
+name: Model Regression
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  model-regression:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
+    secrets: inherit

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,0 +1,11 @@
+name: Test Coverage
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
+    secrets: inherit

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -1,0 +1,12 @@
+name: Update Badges
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  badges:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # ubcpdk (SiEPIC Ebeam PDK) 3.3.4
 
+<!-- BADGES:START -->
+[![Docs](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml)
+[![Tests](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml)
+[![DRC](https://github.com/gdsfactory/ubc/actions/workflows/drc.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/drc.yml)
+[![Model Regression](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml)
+[![Test Coverage](https://github.com/gdsfactory/ubc/raw/badges/coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_coverage.yml)
+[![Model Coverage](https://github.com/gdsfactory/ubc/raw/badges/model_coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_coverage.yml)
+[![Issues](https://github.com/gdsfactory/ubc/raw/badges/issues.svg)](https://github.com/gdsfactory/ubc/issues)
+[![PRs](https://github.com/gdsfactory/ubc/raw/badges/prs.svg)](https://github.com/gdsfactory/ubc/pulls)
+<!-- BADGES:END -->
+
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD)
 [![pypi](https://img.shields.io/pypi/v/ubcpdk)](https://pypi.org/project/ubcpdk/)
 [![mit](https://img.shields.io/github/license/gdsfactory/ubc)](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
## Summary

- Add 4 new CI workflows using centralized reusable workflows from `doplaydo/pdk-ci-workflow`:
  - **model_coverage.yml** — reports fraction of cells with models
  - **model_regression.yml** — runs `make test -k model` to catch regressions
  - **test_coverage.yml** — runs `make test` with `--cov` pinned to package
  - **update_badges.yml** — generates SVG badges (coverage %, models %, issues, PRs)
- Update README with clickable badge dashboard

All logic is centralized — each workflow file is a thin caller (~10 lines).

## Test plan

- [ ] Verify all new workflows pass
- [ ] Check badges render in README after first `update_badges` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add CI workflows for model and test coverage, regression checks, and badge generation, and surface their status in the README via a badges dashboard.

New Features:
- Introduce model coverage, model regression, and test coverage GitHub Actions workflows using centralized reusable workflows.
- Add an automated badge update workflow to generate SVG badges for coverage, models, issues, and pull requests.

CI:
- Add GitHub Actions workflows for model coverage, model regression, and test coverage, triggered on pushes, pull requests, and manual dispatch.
- Add a scheduled and manually triggerable workflow to regenerate and update repository badges.

Documentation:
- Update README to include a badges dashboard showing docs, tests, DRC, coverage, model coverage, issues, and PR status.