### PR TITLE
add type tags to all @cell components

### DIFF
--- a/ubcpdk/cells/containers.py
+++ b/ubcpdk/cells/containers.py
@@ -79,7 +79,7 @@ def get_input_label_text(
     return f"opt_in_{polarization.upper()}_{int(wavelength * 1000.0)}_device_{username}-{name}"
 
 
-@gf.cell
+@gf.cell(tags={"type": "containers"})
 def add_fiber_array(
     component: ComponentSpec = "ring_single",
     component_name: str | None = None,
@@ -147,7 +147,7 @@ pack_doe = gf.c.pack_doe
 pack_doe_grid = gf.c.pack_doe_grid
 
 
-@gf.cell
+@gf.cell(tags={"type": "containers"})
 def add_fiber_array_pads_rf(
     component: ComponentSpec = "ring_single_heater",
     username: str = CONFIG.username,
@@ -178,7 +178,7 @@ def add_fiber_array_pads_rf(
     return add_fiber_array(component=c1, component_name=component_name, **kwargs)
 
 
-@gf.cell
+@gf.cell(tags={"type": "containers"})
 def pad_array(
     pad: ComponentSpec = "pad",
     columns: int = 6,
@@ -226,7 +226,7 @@ add_pads_rf = partial(
 )
 
 
-@gf.cell
+@gf.cell(tags={"type": "containers"})
 def add_pads(
     component: ComponentSpec = "ring_single_heater",
     username: str = CONFIG.username,

--- a/ubcpdk/cells/containers.py
+++ b/ubcpdk/cells/containers.py
@@ -79,7 +79,7 @@ def get_input_label_text(
     return f"opt_in_{polarization.upper()}_{int(wavelength * 1000.0)}_device_{username}-{name}"
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["containers"])
 def add_fiber_array(
     component: ComponentSpec = "ring_single",
     component_name: str | None = None,
@@ -147,7 +147,7 @@ pack_doe = gf.c.pack_doe
 pack_doe_grid = gf.c.pack_doe_grid
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["containers"])
 def add_fiber_array_pads_rf(
     component: ComponentSpec = "ring_single_heater",
     username: str = CONFIG.username,
@@ -178,7 +178,7 @@ def add_fiber_array_pads_rf(
     return add_fiber_array(component=c1, component_name=component_name, **kwargs)
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["containers"])
 def pad_array(
     pad: ComponentSpec = "pad",
     columns: int = 6,
@@ -226,7 +226,7 @@ add_pads_rf = partial(
 )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["containers"])
 def add_pads(
     component: ComponentSpec = "ring_single_heater",
     username: str = CONFIG.username,

--- a/ubcpdk/cells/couplers.py
+++ b/ubcpdk/cells/couplers.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ubcpdk.tech import TECH
 
 
-@gf.cell
+@gf.cell(tags={"type": "couplers"})
 def coupler(length: float = 14.5, gap: float = TECH.gap) -> gf.Component:
     """Returns Symmetric coupler.
 
@@ -24,7 +24,7 @@ def coupler(length: float = 14.5, gap: float = TECH.gap) -> gf.Component:
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "couplers"})
 def coupler_ring(
     length_x: float = 4,
     gap: float = TECH.gap,

--- a/ubcpdk/cells/couplers.py
+++ b/ubcpdk/cells/couplers.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ubcpdk.tech import TECH
 
 
-@gf.cell(tags={"type": "couplers"})
+@gf.cell(tags=["couplers"])
 def coupler(length: float = 14.5, gap: float = TECH.gap) -> gf.Component:
     """Returns Symmetric coupler.
 
@@ -24,7 +24,7 @@ def coupler(length: float = 14.5, gap: float = TECH.gap) -> gf.Component:
     )
 
 
-@gf.cell(tags={"type": "couplers"})
+@gf.cell(tags=["couplers"])
 def coupler_ring(
     length_x: float = 4,
     gap: float = TECH.gap,

--- a/ubcpdk/cells/die_with_pads.py
+++ b/ubcpdk/cells/die_with_pads.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import (
 from ubcpdk.tech import LAYER
 
 
-@gf.cell
+@gf.cell(tags={"type": "die"})
 def compass(
     size: Size = (4, 2),
     layer: LayerSpec = "MTOP",
@@ -39,7 +39,7 @@ def compass(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "die"})
 def rectangle(
     size: Size = (4, 2),
     layer: LayerSpec = "MTOP",
@@ -65,7 +65,7 @@ def rectangle(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "die"})
 def pad(
     size: tuple[float, float] = (90.0, 90.0),
     layer: LayerSpec = "MTOP",
@@ -95,7 +95,7 @@ def pad(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "die"})
 def die(size: tuple[float, float] = (440, 470), centered: bool = False) -> gf.Component:
     """A die.
 

--- a/ubcpdk/cells/die_with_pads.py
+++ b/ubcpdk/cells/die_with_pads.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import (
 from ubcpdk.tech import LAYER
 
 
-@gf.cell(tags={"type": "die"})
+@gf.cell(tags=["die"])
 def compass(
     size: Size = (4, 2),
     layer: LayerSpec = "MTOP",
@@ -39,7 +39,7 @@ def compass(
     )
 
 
-@gf.cell(tags={"type": "die"})
+@gf.cell(tags=["die"])
 def rectangle(
     size: Size = (4, 2),
     layer: LayerSpec = "MTOP",
@@ -65,7 +65,7 @@ def rectangle(
     )
 
 
-@gf.cell(tags={"type": "die"})
+@gf.cell(tags=["die"])
 def pad(
     size: tuple[float, float] = (90.0, 90.0),
     layer: LayerSpec = "MTOP",
@@ -95,7 +95,7 @@ def pad(
     )
 
 
-@gf.cell(tags={"type": "die"})
+@gf.cell(tags=["die"])
 def die(size: tuple[float, float] = (440, 470), centered: bool = False) -> gf.Component:
     """A die.
 

--- a/ubcpdk/cells/fixed_ant.py
+++ b/ubcpdk/cells/fixed_ant.py
@@ -6,13 +6,13 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_ant
 
 
-@gf.cell(tags={"type": "fixed_ant"})
+@gf.cell(tags=["fixed_ant"])
 def ebeam_splitter_swg_assist_te1310_ANT() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1310_ANT fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1310_ANT.GDS")
 
 
-@gf.cell(tags={"type": "fixed_ant"})
+@gf.cell(tags=["fixed_ant"])
 def ebeam_splitter_swg_assist_te1550_ANT() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1550_ANT fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1550_ANT.GDS")

--- a/ubcpdk/cells/fixed_ant.py
+++ b/ubcpdk/cells/fixed_ant.py
@@ -6,13 +6,13 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_ant
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ant"})
 def ebeam_splitter_swg_assist_te1310_ANT() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1310_ANT fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1310_ANT.GDS")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ant"})
 def ebeam_splitter_swg_assist_te1550_ANT() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1550_ANT fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1550_ANT.GDS")

--- a/ubcpdk/cells/fixed_beta.py
+++ b/ubcpdk/cells/fixed_beta.py
@@ -6,145 +6,145 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_beta
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def Alignment_Marker() -> gf.Component:
     """Returns Alignment_Marker fixed cell."""
     return import_gds(gdsdir / "Alignment_Marker.GDS")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def Packaging_FibreArray_8ch() -> gf.Component:
     """Returns Packaging_FibreArray_8ch fixed cell."""
     return import_gds(gdsdir / "Packaging_FibreArray_8ch.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def SEM_example() -> gf.Component:
     """Returns SEM_example fixed cell."""
     return import_gds(gdsdir / "SEM_example.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_BondPad() -> gf.Component:
     """Returns ebeam_BondPad fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_BondPad_75() -> gf.Component:
     """Returns ebeam_BondPad_75 fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad_75.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_bdc_tm1550() -> gf.Component:
     """Returns ebeam_bdc_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_bdc_tm1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_gc_te1310() -> gf.Component:
     """Returns ebeam_gc_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_gc_te1310_broadband() -> gf.Component:
     """Returns ebeam_gc_te1310_broadband fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1310_broadband.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_gc_te1550_90nmSlab() -> gf.Component:
     """Returns ebeam_gc_te1550_90nmSlab fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550_90nmSlab.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_gc_te1550_broadband() -> gf.Component:
     """Returns ebeam_gc_te1550_broadband fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550_broadband.GDS")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_splitter_adiabatic_swg_te1550() -> gf.Component:
     """Returns ebeam_splitter_adiabatic_swg_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_adiabatic_swg_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_swg_edgecoupler() -> gf.Component:
     """Returns ebeam_swg_edgecoupler fixed cell."""
     return import_gds(gdsdir / "ebeam_swg_edgecoupler.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_terminator_te1310() -> gf.Component:
     """Returns ebeam_terminator_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def ebeam_y_adiabatic_1310() -> gf.Component:
     """Returns ebeam_y_adiabatic_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic_1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def metal_via() -> gf.Component:
     """Returns metal_via fixed cell."""
     return import_gds(gdsdir / "metal_via.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def pbs_1550_eskid() -> gf.Component:
     """Returns pbs_1550_eskid fixed cell."""
     return import_gds(gdsdir / "pbs_1550_eskid.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def photonic_wirebond_surfacetaper_1310() -> gf.Component:
     """Returns photonic_wirebond_surfacetaper_1310 fixed cell."""
     return import_gds(gdsdir / "photonic_wirebond_surfacetaper_1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def photonic_wirebond_surfacetaper_1550() -> gf.Component:
     """Returns photonic_wirebond_surfacetaper_1550 fixed cell."""
     return import_gds(gdsdir / "photonic_wirebond_surfacetaper_1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def siepic_o_gc_te1270_BB() -> gf.Component:
     """Returns siepic_o_gc_te1270_BB fixed cell."""
     return import_gds(gdsdir / "siepic_o_gc_te1270_BB.GDS")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def siepic_o_pwbstlas_si_BB() -> gf.Component:
     """Returns siepic_o_pwbstlas_si_BB fixed cell."""
     return import_gds(gdsdir / "siepic_o_pwbstlas_si_BB.GDS")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def thermal_phase_shifter_multimode_() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_multimode_.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def thermal_phase_shifter_te_1310_() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1310_.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def thermal_phase_shifter_te_1310_50() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1310_50.gds")
 
 
-@gf.cell(tags={"type": "fixed_beta"})
+@gf.cell(tags=["fixed_beta"])
 def thermal_phase_shifter_te_1550_50() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1550_50.gds")

--- a/ubcpdk/cells/fixed_beta.py
+++ b/ubcpdk/cells/fixed_beta.py
@@ -6,145 +6,145 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_beta
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def Alignment_Marker() -> gf.Component:
     """Returns Alignment_Marker fixed cell."""
     return import_gds(gdsdir / "Alignment_Marker.GDS")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def Packaging_FibreArray_8ch() -> gf.Component:
     """Returns Packaging_FibreArray_8ch fixed cell."""
     return import_gds(gdsdir / "Packaging_FibreArray_8ch.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def SEM_example() -> gf.Component:
     """Returns SEM_example fixed cell."""
     return import_gds(gdsdir / "SEM_example.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_BondPad() -> gf.Component:
     """Returns ebeam_BondPad fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_BondPad_75() -> gf.Component:
     """Returns ebeam_BondPad_75 fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad_75.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_bdc_tm1550() -> gf.Component:
     """Returns ebeam_bdc_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_bdc_tm1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_gc_te1310() -> gf.Component:
     """Returns ebeam_gc_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_gc_te1310_broadband() -> gf.Component:
     """Returns ebeam_gc_te1310_broadband fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1310_broadband.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_gc_te1550_90nmSlab() -> gf.Component:
     """Returns ebeam_gc_te1550_90nmSlab fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550_90nmSlab.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_gc_te1550_broadband() -> gf.Component:
     """Returns ebeam_gc_te1550_broadband fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550_broadband.GDS")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_splitter_adiabatic_swg_te1550() -> gf.Component:
     """Returns ebeam_splitter_adiabatic_swg_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_adiabatic_swg_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_swg_edgecoupler() -> gf.Component:
     """Returns ebeam_swg_edgecoupler fixed cell."""
     return import_gds(gdsdir / "ebeam_swg_edgecoupler.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_terminator_te1310() -> gf.Component:
     """Returns ebeam_terminator_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def ebeam_y_adiabatic_1310() -> gf.Component:
     """Returns ebeam_y_adiabatic_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic_1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def metal_via() -> gf.Component:
     """Returns metal_via fixed cell."""
     return import_gds(gdsdir / "metal_via.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def pbs_1550_eskid() -> gf.Component:
     """Returns pbs_1550_eskid fixed cell."""
     return import_gds(gdsdir / "pbs_1550_eskid.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def photonic_wirebond_surfacetaper_1310() -> gf.Component:
     """Returns photonic_wirebond_surfacetaper_1310 fixed cell."""
     return import_gds(gdsdir / "photonic_wirebond_surfacetaper_1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def photonic_wirebond_surfacetaper_1550() -> gf.Component:
     """Returns photonic_wirebond_surfacetaper_1550 fixed cell."""
     return import_gds(gdsdir / "photonic_wirebond_surfacetaper_1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def siepic_o_gc_te1270_BB() -> gf.Component:
     """Returns siepic_o_gc_te1270_BB fixed cell."""
     return import_gds(gdsdir / "siepic_o_gc_te1270_BB.GDS")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def siepic_o_pwbstlas_si_BB() -> gf.Component:
     """Returns siepic_o_pwbstlas_si_BB fixed cell."""
     return import_gds(gdsdir / "siepic_o_pwbstlas_si_BB.GDS")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def thermal_phase_shifter_multimode_() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_multimode_.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def thermal_phase_shifter_te_1310_() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1310_.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def thermal_phase_shifter_te_1310_50() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1310_50.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_beta"})
 def thermal_phase_shifter_te_1550_50() -> gf.Component:
     """Returns thermal_phase_shifters fixed cell."""
     return import_gds(gdsdir / "thermal_phase_shifter_te_1550_50.gds")

--- a/ubcpdk/cells/fixed_dream.py
+++ b/ubcpdk/cells/fixed_dream.py
@@ -6,55 +6,55 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_dream
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FAVE_SiN_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_SiN_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_SiN_1310_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FAVE_SiN_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_SiN_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_SiN_1550_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FAVE_Si_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_Si_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_Si_1310_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FAVE_Si_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_Si_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_Si_1550_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FaML_SiN_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_SiN_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_SiN_1550_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FaML_Si_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_Si_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_Si_1310_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_FaML_Si_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_Si_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_Si_1550_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_dream_splitter_1x2_te1550_BB() -> gf.Component:
     """Returns ebeam_dream_splitter_1x2_te1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_splitter_1x2_te1550_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_dream"})
+@gf.cell(tags=["fixed_dream"])
 def ebeam_sin_dream_splitter1x2_te1550_BB() -> gf.Component:
     """Returns ebeam_sin_dream_splitter1x2_te1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_sin_dream_splitter1x2_te1550_BB.gds")

--- a/ubcpdk/cells/fixed_dream.py
+++ b/ubcpdk/cells/fixed_dream.py
@@ -6,55 +6,55 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_dream
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FAVE_SiN_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_SiN_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_SiN_1310_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FAVE_SiN_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_SiN_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_SiN_1550_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FAVE_Si_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_Si_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_Si_1310_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FAVE_Si_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FAVE_Si_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FAVE_Si_1550_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FaML_SiN_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_SiN_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_SiN_1550_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FaML_Si_1310_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_Si_1310_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_Si_1310_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_FaML_Si_1550_BB() -> gf.Component:
     """Returns ebeam_dream_FaML_Si_1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_FaML_Si_1550_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_dream_splitter_1x2_te1550_BB() -> gf.Component:
     """Returns ebeam_dream_splitter_1x2_te1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_dream_splitter_1x2_te1550_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_dream"})
 def ebeam_sin_dream_splitter1x2_te1550_BB() -> gf.Component:
     """Returns ebeam_sin_dream_splitter1x2_te1550_BB fixed cell."""
     return import_gds(gdsdir / "ebeam_sin_dream_splitter1x2_te1550_BB.gds")

--- a/ubcpdk/cells/fixed_ebeam.py
+++ b/ubcpdk/cells/fixed_ebeam.py
@@ -6,67 +6,67 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_ebeam
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def GC_TE_1310_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TE_1310_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def GC_TE_1550_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TE_1550_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def GC_TM_1310_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TM_1310_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def GC_TM_1550_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TM_1550_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_adiabatic_te1550() -> gf.Component:
     """Returns ebeam_adiabatic_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_adiabatic_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_adiabatic_tm1550() -> gf.Component:
     """Returns ebeam_adiabatic_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_adiabatic_tm1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_bdc_te1550() -> gf.Component:
     """Returns ebeam_bdc_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_bdc_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_crossing4() -> gf.Component:
     """Returns ebeam_crossing4 fixed cell."""
     return import_gds(gdsdir / "ebeam_crossing4.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_gc_te1550() -> gf.Component:
     """Returns ebeam_gc_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_gc_tm1550() -> gf.Component:
     """Returns ebeam_gc_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_tm1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um() -> gf.Component:
     """Returns ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um fixed cell."""
     return import_gds(
@@ -74,7 +74,7 @@ def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um() -> gf.Component:
     )
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um() -> gf.Component:
     """Returns ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um fixed cell."""
     return import_gds(
@@ -82,67 +82,67 @@ def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um() -> gf.Component:
     )
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_splitter_swg_assist_te1310() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_splitter_swg_assist_te1550() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_terminator_te1310() -> gf.Component:
     """Returns ebeam_terminator_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_terminator_te1550() -> gf.Component:
     """Returns ebeam_terminator_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_terminator_tm1550() -> gf.Component:
     """Returns ebeam_terminator_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_tm1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_y_1310() -> gf.Component:
     """Returns ebeam_y_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_y_1550() -> gf.Component:
     """Returns ebeam_y_1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_y_adiabatic() -> gf.Component:
     """Returns ebeam_y_adiabatic fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def ebeam_y_adiabatic_500pin() -> gf.Component:
     """Returns ebeam_y_adiabatic_500pin fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic_500pin.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def taper_si_simm_1310() -> gf.Component:
     """Returns taper_si_simm_1310 fixed cell."""
     return import_gds(gdsdir / "taper_si_simm_1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_ebeam"})
+@gf.cell(tags=["fixed_ebeam"])
 def taper_si_simm_1550() -> gf.Component:
     """Returns taper_si_simm_1550 fixed cell."""
     return import_gds(gdsdir / "taper_si_simm_1550.gds")

--- a/ubcpdk/cells/fixed_ebeam.py
+++ b/ubcpdk/cells/fixed_ebeam.py
@@ -6,67 +6,67 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_ebeam
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def GC_TE_1310_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TE_1310_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def GC_TE_1550_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TE_1550_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def GC_TM_1310_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TM_1310_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def GC_TM_1550_8degOxide_BB() -> gf.Component:
     """Returns GCs_BB fixed cell."""
     return import_gds(gdsdir / "GC_TM_1550_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_adiabatic_te1550() -> gf.Component:
     """Returns ebeam_adiabatic_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_adiabatic_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_adiabatic_tm1550() -> gf.Component:
     """Returns ebeam_adiabatic_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_adiabatic_tm1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_bdc_te1550() -> gf.Component:
     """Returns ebeam_bdc_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_bdc_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_crossing4() -> gf.Component:
     """Returns ebeam_crossing4 fixed cell."""
     return import_gds(gdsdir / "ebeam_crossing4.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_gc_te1550() -> gf.Component:
     """Returns ebeam_gc_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_gc_tm1550() -> gf.Component:
     """Returns ebeam_gc_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_tm1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um() -> gf.Component:
     """Returns ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um fixed cell."""
     return import_gds(
@@ -74,7 +74,7 @@ def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um() -> gf.Component:
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um() -> gf.Component:
     """Returns ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um fixed cell."""
     return import_gds(
@@ -82,67 +82,67 @@ def ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um() -> gf.Component:
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_splitter_swg_assist_te1310() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_splitter_swg_assist_te1550() -> gf.Component:
     """Returns ebeam_splitter_swg_assist_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_splitter_swg_assist_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_terminator_te1310() -> gf.Component:
     """Returns ebeam_terminator_te1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_terminator_te1550() -> gf.Component:
     """Returns ebeam_terminator_te1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_te1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_terminator_tm1550() -> gf.Component:
     """Returns ebeam_terminator_tm1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_tm1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_y_1310() -> gf.Component:
     """Returns ebeam_y_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_y_1550() -> gf.Component:
     """Returns ebeam_y_1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_y_1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_y_adiabatic() -> gf.Component:
     """Returns ebeam_y_adiabatic fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def ebeam_y_adiabatic_500pin() -> gf.Component:
     """Returns ebeam_y_adiabatic_500pin fixed cell."""
     return import_gds(gdsdir / "ebeam_y_adiabatic_500pin.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def taper_si_simm_1310() -> gf.Component:
     """Returns taper_si_simm_1310 fixed cell."""
     return import_gds(gdsdir / "taper_si_simm_1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_ebeam"})
 def taper_si_simm_1550() -> gf.Component:
     """Returns taper_si_simm_1550 fixed cell."""
     return import_gds(gdsdir / "taper_si_simm_1550.gds")

--- a/ubcpdk/cells/fixed_single.py
+++ b/ubcpdk/cells/fixed_single.py
@@ -6,117 +6,117 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_single
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ANT_MMI_1x2_te1550_3dB_BB() -> gf.Component:
     """Returns ANT_MMI_1x2_te1550_3dB_BB fixed cell."""
     return import_gds(gdsdir / "ANT_MMI_1x2_te1550_3dB_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def GC_SiN_TE_1310_8degOxide_BB() -> gf.Component:
     """Returns GC_SiN_TE_1310_8degOxide_BB fixed cell."""
     return import_gds(gdsdir / "GC_SiN_TE_1310_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def GC_SiN_TE_1550_8degOxide_BB() -> gf.Component:
     """Returns GC_SiN_TE_1550_8degOxide_BB fixed cell."""
     return import_gds(gdsdir / "GC_SiN_TE_1550_8degOxide_BB.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_MMI_2x2_5050_te1310() -> gf.Component:
     """Returns ULaval fixed cell."""
     cell = "ebeam_MMI_2x2_5050_te1310.gds"
     return import_gds(gdsdir / cell)
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_YBranch_te1310() -> gf.Component:
     """Returns ULaval fixed cell."""
     cell = "ebeam_YBranch_te1310.gds"
     return import_gds(gdsdir / cell)
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def crossing_SiN_1550() -> gf.Component:
     """Returns crossing_SiN_1550 fixed cell."""
     return import_gds(gdsdir / "crossing_SiN_1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def crossing_SiN_1550_extended() -> gf.Component:
     """Returns crossing_SiN_1550_extended fixed cell."""
     return import_gds(gdsdir / "crossing_SiN_1550_extended.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def crossing_horizontal() -> gf.Component:
     """Returns crossing_horizontal fixed cell."""
     return import_gds(gdsdir / "crossing_horizontal.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def crossing_manhattan() -> gf.Component:
     """Returns crossing_manhattan fixed cell."""
     return import_gds(gdsdir / "crossing_manhattan.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_BondPad() -> gf.Component:
     """Returns ebeam_BondPad fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_DC_2m1_te895() -> gf.Component:
     """Returns ebeam_DC_2m1_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_DC_2-1_te895.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_DC_te895() -> gf.Component:
     """Returns ebeam_DC_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_DC_te895.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_Polarizer_TM_1550_UQAM() -> gf.Component:
     """Returns ebeam_Polarizer_TM_1550_UQAM fixed cell."""
     return import_gds(gdsdir / "ebeam_Polarizer_TM_1550_UQAM.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_YBranch_895() -> gf.Component:
     """Returns ebeam_YBranch_895 fixed cell."""
     return import_gds(gdsdir / "ebeam_YBranch_895.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_gc_te895() -> gf.Component:
     """Returns ebeam_gc_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te895.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_terminator_SiN_1310() -> gf.Component:
     """Returns ebeam_terminator_SiN_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_1310.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_terminator_SiN_1550() -> gf.Component:
     """Returns ebeam_terminator_SiN_1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_1550.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def ebeam_terminator_SiN_te895() -> gf.Component:
     """Returns ebeam_terminator_SiN_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_te895.gds")
 
 
-@gf.cell(tags={"type": "fixed_single"})
+@gf.cell(tags=["fixed_single"])
 def taper_SiN_750_3000() -> gf.Component:
     """Returns taper_SiN_750_3000 fixed cell."""
     return import_gds(gdsdir / "taper_SiN_750_3000.gds")

--- a/ubcpdk/cells/fixed_single.py
+++ b/ubcpdk/cells/fixed_single.py
@@ -6,117 +6,117 @@ from ubcpdk.import_gds import import_gds
 gdsdir = PATH.gds_single
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ANT_MMI_1x2_te1550_3dB_BB() -> gf.Component:
     """Returns ANT_MMI_1x2_te1550_3dB_BB fixed cell."""
     return import_gds(gdsdir / "ANT_MMI_1x2_te1550_3dB_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def GC_SiN_TE_1310_8degOxide_BB() -> gf.Component:
     """Returns GC_SiN_TE_1310_8degOxide_BB fixed cell."""
     return import_gds(gdsdir / "GC_SiN_TE_1310_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def GC_SiN_TE_1550_8degOxide_BB() -> gf.Component:
     """Returns GC_SiN_TE_1550_8degOxide_BB fixed cell."""
     return import_gds(gdsdir / "GC_SiN_TE_1550_8degOxide_BB.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_MMI_2x2_5050_te1310() -> gf.Component:
     """Returns ULaval fixed cell."""
     cell = "ebeam_MMI_2x2_5050_te1310.gds"
     return import_gds(gdsdir / cell)
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_YBranch_te1310() -> gf.Component:
     """Returns ULaval fixed cell."""
     cell = "ebeam_YBranch_te1310.gds"
     return import_gds(gdsdir / cell)
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def crossing_SiN_1550() -> gf.Component:
     """Returns crossing_SiN_1550 fixed cell."""
     return import_gds(gdsdir / "crossing_SiN_1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def crossing_SiN_1550_extended() -> gf.Component:
     """Returns crossing_SiN_1550_extended fixed cell."""
     return import_gds(gdsdir / "crossing_SiN_1550_extended.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def crossing_horizontal() -> gf.Component:
     """Returns crossing_horizontal fixed cell."""
     return import_gds(gdsdir / "crossing_horizontal.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def crossing_manhattan() -> gf.Component:
     """Returns crossing_manhattan fixed cell."""
     return import_gds(gdsdir / "crossing_manhattan.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_BondPad() -> gf.Component:
     """Returns ebeam_BondPad fixed cell."""
     return import_gds(gdsdir / "ebeam_BondPad.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_DC_2m1_te895() -> gf.Component:
     """Returns ebeam_DC_2m1_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_DC_2-1_te895.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_DC_te895() -> gf.Component:
     """Returns ebeam_DC_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_DC_te895.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_Polarizer_TM_1550_UQAM() -> gf.Component:
     """Returns ebeam_Polarizer_TM_1550_UQAM fixed cell."""
     return import_gds(gdsdir / "ebeam_Polarizer_TM_1550_UQAM.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_YBranch_895() -> gf.Component:
     """Returns ebeam_YBranch_895 fixed cell."""
     return import_gds(gdsdir / "ebeam_YBranch_895.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_gc_te895() -> gf.Component:
     """Returns ebeam_gc_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_gc_te895.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_terminator_SiN_1310() -> gf.Component:
     """Returns ebeam_terminator_SiN_1310 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_1310.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_terminator_SiN_1550() -> gf.Component:
     """Returns ebeam_terminator_SiN_1550 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_1550.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def ebeam_terminator_SiN_te895() -> gf.Component:
     """Returns ebeam_terminator_SiN_te895 fixed cell."""
     return import_gds(gdsdir / "ebeam_terminator_SiN_te895.gds")
 
 
-@gf.cell
+@gf.cell(tags={"type": "fixed_single"})
 def taper_SiN_750_3000() -> gf.Component:
     """Returns taper_SiN_750_3000 fixed cell."""
     return import_gds(gdsdir / "taper_SiN_750_3000.gds")

--- a/ubcpdk/cells/grating_couplers.py
+++ b/ubcpdk/cells/grating_couplers.py
@@ -3,7 +3,7 @@
 import gdsfactory as gf
 
 
-@gf.cell
+@gf.cell(tags={"type": "grating_couplers"})
 def grating_coupler_elliptical(
     wavelength: float = 1.55,
     grating_line_width=0.315,

--- a/ubcpdk/cells/grating_couplers.py
+++ b/ubcpdk/cells/grating_couplers.py
@@ -3,7 +3,7 @@
 import gdsfactory as gf
 
 
-@gf.cell(tags={"type": "grating_couplers"})
+@gf.cell(tags=["grating_couplers"])
 def grating_coupler_elliptical(
     wavelength: float = 1.55,
     grating_line_width=0.315,

--- a/ubcpdk/cells/heaters.py
+++ b/ubcpdk/cells/heaters.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
 
-@gf.cell(tags={"type": "heaters"})
+@gf.cell(tags=["heaters"])
 def straight_heater_metal(
     length: float = 320.0,
     length_undercut_spacing: float = 6.0,
@@ -47,7 +47,7 @@ def straight_heater_metal(
     )
 
 
-@gf.cell(tags={"type": "heaters"})
+@gf.cell(tags=["heaters"])
 def straight_heater_meander(
     length: float = 320.0,
     heater_width: float = 2.5,

--- a/ubcpdk/cells/heaters.py
+++ b/ubcpdk/cells/heaters.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "heaters"})
 def straight_heater_metal(
     length: float = 320.0,
     length_undercut_spacing: float = 6.0,
@@ -47,7 +47,7 @@ def straight_heater_metal(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "heaters"})
 def straight_heater_meander(
     length: float = 320.0,
     heater_width: float = 2.5,

--- a/ubcpdk/cells/mmis.py
+++ b/ubcpdk/cells/mmis.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import (
 ################
 
 
-@gf.cell
+@gf.cell(tags={"type": "mmis"})
 def mmi1x2(
     width: float | None = None,
     width_taper: float = 1.5,
@@ -44,7 +44,7 @@ def mmi1x2(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "mmis"})
 def mmi2x2(
     width: float | None = None,
     width_taper: float = 1.5,

--- a/ubcpdk/cells/mmis.py
+++ b/ubcpdk/cells/mmis.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import (
 ################
 
 
-@gf.cell(tags={"type": "mmis"})
+@gf.cell(tags=["mmis"])
 def mmi1x2(
     width: float | None = None,
     width_taper: float = 1.5,
@@ -44,7 +44,7 @@ def mmi1x2(
     )
 
 
-@gf.cell(tags={"type": "mmis"})
+@gf.cell(tags=["mmis"])
 def mmi2x2(
     width: float | None = None,
     width_taper: float = 1.5,

--- a/ubcpdk/cells/mzis.py
+++ b/ubcpdk/cells/mzis.py
@@ -9,7 +9,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell
+@gf.cell(tags={"type": "mzis"})
 def mzi_1x1(
     delta_length: float = 10,
     bend: ComponentSpec = "bend_euler",
@@ -69,7 +69,7 @@ def mzi_1x1(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "mzis"})
 def mzi(
     delta_length: float = 10,
     bend: ComponentSpec = "bend_euler",
@@ -137,7 +137,7 @@ def mzi(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "mzis"})
 def mzi_heater(
     delta_length: float = 10,
     length_x: float = 200,
@@ -165,7 +165,7 @@ def mzi_heater(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "mzis"})
 def mzi_heater_2x2(
     delta_length: float = 10,
     length_x: float = 200,

--- a/ubcpdk/cells/mzis.py
+++ b/ubcpdk/cells/mzis.py
@@ -9,7 +9,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell(tags={"type": "mzis"})
+@gf.cell(tags=["mzis"])
 def mzi_1x1(
     delta_length: float = 10,
     bend: ComponentSpec = "bend_euler",
@@ -69,7 +69,7 @@ def mzi_1x1(
     )
 
 
-@gf.cell(tags={"type": "mzis"})
+@gf.cell(tags=["mzis"])
 def mzi(
     delta_length: float = 10,
     bend: ComponentSpec = "bend_euler",
@@ -137,7 +137,7 @@ def mzi(
     )
 
 
-@gf.cell(tags={"type": "mzis"})
+@gf.cell(tags=["mzis"])
 def mzi_heater(
     delta_length: float = 10,
     length_x: float = 200,
@@ -165,7 +165,7 @@ def mzi_heater(
     return c
 
 
-@gf.cell(tags={"type": "mzis"})
+@gf.cell(tags=["mzis"])
 def mzi_heater_2x2(
     delta_length: float = 10,
     length_x: float = 200,

--- a/ubcpdk/cells/rings.py
+++ b/ubcpdk/cells/rings.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, 
 from ubcpdk.tech import TECH
 
 
-@gf.cell(tags={"type": "rings"})
+@gf.cell(tags=["rings"])
 def ring_single(
     gap: float = TECH.gap_strip,
     radius: float = 10.0,
@@ -65,7 +65,7 @@ def ring_single(
     )
 
 
-@gf.cell(tags={"type": "rings"})
+@gf.cell(tags=["rings"])
 def ring_double(
     gap: float = TECH.gap_strip,
     gap_top: float | None = None,
@@ -110,7 +110,7 @@ def ring_double(
     )
 
 
-@gf.cell(tags={"type": "rings"})
+@gf.cell(tags=["rings"])
 def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,
@@ -201,7 +201,7 @@ def ring_double_heater(
     )
 
 
-@gf.cell(tags={"type": "rings"})
+@gf.cell(tags=["rings"])
 def ring_single_heater(
     gap: float = 0.2,
     radius: float = 10.0,

--- a/ubcpdk/cells/rings.py
+++ b/ubcpdk/cells/rings.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, 
 from ubcpdk.tech import TECH
 
 
-@gf.cell
+@gf.cell(tags={"type": "rings"})
 def ring_single(
     gap: float = TECH.gap_strip,
     radius: float = 10.0,
@@ -65,7 +65,7 @@ def ring_single(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "rings"})
 def ring_double(
     gap: float = TECH.gap_strip,
     gap_top: float | None = None,
@@ -110,7 +110,7 @@ def ring_double(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "rings"})
 def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,
@@ -201,7 +201,7 @@ def ring_double_heater(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "rings"})
 def ring_single_heater(
     gap: float = 0.2,
     radius: float = 10.0,

--- a/ubcpdk/cells/spirals.py
+++ b/ubcpdk/cells/spirals.py
@@ -8,7 +8,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell
+@gf.cell(tags={"type": "spirals"})
 def spiral(
     length: float = 100,
     cross_section: CrossSectionSpec = "strip",
@@ -33,7 +33,7 @@ def spiral(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "spirals"})
 def spiral_racetrack(
     min_radius: float | None = None,
     straight_length: float = 20.0,
@@ -74,7 +74,7 @@ def spiral_racetrack(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "spirals"})
 def spiral_racetrack_heater(
     spacing: float = 4.0,
     num: int = 8,

--- a/ubcpdk/cells/spirals.py
+++ b/ubcpdk/cells/spirals.py
@@ -8,7 +8,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell(tags={"type": "spirals"})
+@gf.cell(tags=["spirals"])
 def spiral(
     length: float = 100,
     cross_section: CrossSectionSpec = "strip",
@@ -33,7 +33,7 @@ def spiral(
     )
 
 
-@gf.cell(tags={"type": "spirals"})
+@gf.cell(tags=["spirals"])
 def spiral_racetrack(
     min_radius: float | None = None,
     straight_length: float = 20.0,
@@ -74,7 +74,7 @@ def spiral_racetrack(
     )
 
 
-@gf.cell(tags={"type": "spirals"})
+@gf.cell(tags=["spirals"])
 def spiral_racetrack_heater(
     spacing: float = 4.0,
     num: int = 8,

--- a/ubcpdk/cells/tapers.py
+++ b/ubcpdk/cells/tapers.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import CrossSectionSpec
 from ubcpdk.tech import TECH
 
 
-@gf.cell
+@gf.cell(tags={"type": "tapers"})
 def taper(
     length: float = 10.0,
     width1: float = TECH.width,
@@ -35,7 +35,7 @@ def taper(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "tapers"})
 def taper_metal(
     length: float = 10.0,
     width1: float = TECH.width_metal,

--- a/ubcpdk/cells/tapers.py
+++ b/ubcpdk/cells/tapers.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import CrossSectionSpec
 from ubcpdk.tech import TECH
 
 
-@gf.cell(tags={"type": "tapers"})
+@gf.cell(tags=["tapers"])
 def taper(
     length: float = 10.0,
     width1: float = TECH.width,
@@ -35,7 +35,7 @@ def taper(
     )
 
 
-@gf.cell(tags={"type": "tapers"})
+@gf.cell(tags=["tapers"])
 def taper_metal(
     length: float = 10.0,
     width1: float = TECH.width_metal,

--- a/ubcpdk/cells/text.py
+++ b/ubcpdk/cells/text.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
 
 
-@gf.cell
+@gf.cell(tags={"type": "text"})
 def text_rectangular(
     text: str = "abc",
     size: float = 3,
@@ -26,7 +26,7 @@ def text_rectangular(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "text"})
 def text_rectangular_multi_layer(
     text: str = "abc",
     layers: LayerSpecs = ("WG", "M2_ROUTER"),

--- a/ubcpdk/cells/text.py
+++ b/ubcpdk/cells/text.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["text"])
 def text_rectangular(
     text: str = "abc",
     size: float = 3,
@@ -26,7 +26,7 @@ def text_rectangular(
     )
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["text"])
 def text_rectangular_multi_layer(
     text: str = "abc",
     layers: LayerSpecs = ("WG", "M2_ROUTER"),

--- a/ubcpdk/cells/vias.py
+++ b/ubcpdk/cells/vias.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell
+@gf.cell(tags={"type": "vias"})
 def via_stack_heater_mtop(size: Size = (20.0, 10.0)) -> gf.Component:
     """Rectangular via array stack.
 

--- a/ubcpdk/cells/vias.py
+++ b/ubcpdk/cells/vias.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell(tags={"type": "vias"})
+@gf.cell(tags=["vias"])
 def via_stack_heater_mtop(size: Size = (20.0, 10.0)) -> gf.Component:
     """Rectangular via array stack.
 

--- a/ubcpdk/cells/waveguides.py
+++ b/ubcpdk/cells/waveguides.py
@@ -7,7 +7,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 from ubcpdk.tech import TECH
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "strip",
@@ -27,7 +27,7 @@ def straight(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_euler(
     radius: float | None = None,
     angle: float = 90,
@@ -59,7 +59,7 @@ def bend_euler(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "strip",
@@ -86,7 +86,7 @@ def bend_s(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing",
     width: float | None = None,
@@ -108,7 +108,7 @@ def wire_corner(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -134,7 +134,7 @@ def wire_corner45(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner45_straight(
     width: float | None = TECH.width_metal,
     radius: float | None = TECH.width_metal,
@@ -159,7 +159,7 @@ def wire_corner45_straight(
 ####################
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def straight_metal(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal_routing",
@@ -177,7 +177,7 @@ def straight_metal(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_metal(
     radius: float | None = None,
     angle: float = 90,
@@ -209,7 +209,7 @@ def bend_metal(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def bend_s_metal(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal_routing",

--- a/ubcpdk/cells/waveguides.py
+++ b/ubcpdk/cells/waveguides.py
@@ -7,7 +7,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 from ubcpdk.tech import TECH
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "strip",
@@ -27,7 +27,7 @@ def straight(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_euler(
     radius: float | None = None,
     angle: float = 90,
@@ -59,7 +59,7 @@ def bend_euler(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "strip",
@@ -86,7 +86,7 @@ def bend_s(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing",
     width: float | None = None,
@@ -108,7 +108,7 @@ def wire_corner(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -134,7 +134,7 @@ def wire_corner45(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner45_straight(
     width: float | None = TECH.width_metal,
     radius: float | None = TECH.width_metal,
@@ -159,7 +159,7 @@ def wire_corner45_straight(
 ####################
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def straight_metal(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal_routing",
@@ -177,7 +177,7 @@ def straight_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_metal(
     radius: float | None = None,
     angle: float = 90,
@@ -209,7 +209,7 @@ def bend_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def bend_s_metal(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal_routing",


### PR DESCRIPTION
## Summary
- Adds `tags={"type": "<filename>"}` to all `@gf.cell` and `@gf.cell_with_module_name` decorators
- Type is derived from the source filename (e.g., `waveguides.py` → `"waveguides"`, `couplers.py` → `"couplers"`)
- Enables filtering and categorization of components by type

Mirrors the change in gdsfactory: https://github.com/gdsfactory/gdsfactory/commit/4c216c5ef

## Test plan
- [ ] Verify all cells still instantiate correctly via `make test`
- [ ] Check that tags appear in cell metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add type tags to all ubcpdk cell components to support component categorization and filtering.

New Features:
- Annotate all @gf.cell components with a type tag derived from their source module name for metadata-based filtering.

Enhancements:
- Align ubcpdk cell metadata tagging with the corresponding gdsfactory convention across all cell modules.