### PR TITLE
chore: sync pages.yml + dependabot from upstream template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      # actions/deploy-pages is pinned in templates/.github/workflows/pages.yml
+      # and kept in sync by check_template_drift.py. Bumping it here causes drift
+      # churn — upgrades are owned by the pdk-ci-workflow repo.
+      - dependency-name: "actions/deploy-pages"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   drc:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-regression:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,3 +9,17 @@ jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
     secrets: inherit
+  deploy-docs:
+    needs: docs
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
   deploy-docs:
     needs: docs
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -9,4 +9,5 @@ on:
 jobs:
   badges:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,6 +40,8 @@ repository:
 #   colab_url: "https://colab.research.google.com"
 
 sphinx:
+  local_extensions:
+    activate_pdk: _ext
   extra_extensions:
     - "sphinx.ext.autodoc"
     - "sphinx.ext.autodoc.typehints"

--- a/docs/_ext/activate_pdk.py
+++ b/docs/_ext/activate_pdk.py
@@ -1,0 +1,13 @@
+"""Sphinx extension: activate ubcpdk PDK for docs build.
+
+Autodoc renders cell docstrings that instantiate partials requiring an
+active PDK. The package itself no longer activates on import, so we
+activate here for the docs build only.
+"""
+
+import ubcpdk
+
+
+def setup(app):
+    ubcpdk.PDK.activate()
+    return {"version": "0.1", "parallel_read_safe": True}

--- a/ubcpdk/__init__.py
+++ b/ubcpdk/__init__.py
@@ -50,7 +50,6 @@ PDK = Pdk(
     connectivity=connectivity,
     routing_strategies=routing_strategies,
 )
-PDK.activate()
 
 GPATH.sparameters = PATH.sparameters
 GPATH.interconnect = PATH.interconnect_cml_path

--- a/ubcpdk/__init__.py
+++ b/ubcpdk/__init__.py
@@ -50,6 +50,7 @@ PDK = Pdk(
     connectivity=connectivity,
     routing_strategies=routing_strategies,
 )
+PDK.activate()
 
 GPATH.sparameters = PATH.sparameters
 GPATH.interconnect = PATH.interconnect_cml_path


### PR DESCRIPTION
## Summary
- Syncs `.github/workflows/pages.yml` and `.github/dependabot.yml` from [doplaydo/pdk-ci-workflow#117](https://github.com/doplaydo/pdk-ci-workflow/pull/117)
- `deploy-docs` now runs inline in the caller (reusable workflow could not satisfy `workflow_call` + `environment` + per-job `permissions`, causing `startup_failure` with zero logs)
- `actions/deploy-pages` added to dependabot ignore list — the SHA is pinned in the template and kept in sync by `check_template_drift.py`, so bumps here would churn

## Test plan
- [ ] Verify `Build docs` workflow runs without `startup_failure`
- [ ] On merge to `main`, confirm docs deploy to GitHub Pages

## Summary by Sourcery

Inline the documentation deployment job into the pages workflow and align GitHub config with the upstream CI template.

Build:
- Add a deploy-docs job to the pages workflow to publish docs to GitHub Pages on main with appropriate permissions and environment settings.
- Update Dependabot configuration to ignore actions/deploy-pages since it is pinned and managed by the upstream template.