### PR TITLE
add layer_transitions to PDK

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,11 @@
+"""Test routing with layer_transitions and auto-taper."""
+
+from ubcpdk import PDK
+from ubcpdk.samples.sample_routing import sample_routing_different_widths
+
+
+def test_sample_routing_different_widths() -> None:
+    """Test that routing two straights with different widths works."""
+    PDK.activate()
+    c = sample_routing_different_widths()
+    assert c.ports, "Component should have ports"

--- a/ubcpdk/__init__.py
+++ b/ubcpdk/__init__.py
@@ -38,6 +38,11 @@ __all__ = [
 
 connectivity = cast(list[ConnectivitySpec], [("M1_HEATER", "M1_HEATER", "M2_ROUTER")])
 
+layer_transitions = {
+    LAYER.WG: cells.taper,
+    LAYER.M2_ROUTER: cells.taper_metal,
+}
+
 _cells = get_cells(cells)
 PDK = Pdk(
     name="ubcpdk",
@@ -49,6 +54,7 @@ PDK = Pdk(
     layer_views=LAYER_VIEWS,
     connectivity=connectivity,
     routing_strategies=routing_strategies,
+    layer_transitions=layer_transitions,
 )
 
 GPATH.sparameters = PATH.sparameters

--- a/ubcpdk/samples/sample_routing.py
+++ b/ubcpdk/samples/sample_routing.py
@@ -1,0 +1,26 @@
+"""Sample routing two straights with different widths using layer_transitions."""
+
+import gdsfactory as gf
+
+from ubcpdk import PDK, cells, tech
+
+
+@gf.cell
+def sample_routing_different_widths() -> gf.Component:
+    """Route two straights with different widths to test auto-taper."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10, cross_section=tech.strip(width=0.4))
+    s2 = c << cells.straight(length=10, cross_section=tech.strip(width=1.0))
+    s2.dmove((100, 50))
+    tech.route_single(
+        c,
+        s1.ports["o2"],
+        s2.ports["o1"],
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = sample_routing_different_widths()
+    c.show()


### PR DESCRIPTION
## Summary
- Add `layer_transitions` dict mapping `LAYER.WG` to `cells.taper` and `LAYER.M2_ROUTER` to `cells.taper_metal`
- Pass `layer_transitions` to the `Pdk` constructor, enabling automatic width transitions during routing

## Test plan
- [ ] Verify PDK activates without errors
- [ ] Test routing with auto-taper between different waveguide widths

## Summary by Sourcery

Add layer transition configuration to the PDK to enable automatic width transitions during routing.

New Features:
- Configure layer-to-taper cell mappings for waveguide and metal routing layers.
- Pass the new layer transition mappings into the PDK so routing can automatically insert taper cells.