### PR TITLE
chore: add auto-label-pdk workflow

### DIFF
--- a/.github/workflows/auto-label-pdk.yml
+++ b/.github/workflows/auto-label-pdk.yml
@@ -1,0 +1,71 @@
+name: Auto-label PDK issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - pinned
+      - unpinned
+      - closed
+      - reopened
+      - assigned
+      - unassigned
+      - unlabeled
+      - locked
+      - unlocked
+      - transferred
+      - milestoned
+      - demilestoned
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply pdk:<name> label to the issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const slug = context.repo.repo.toLowerCase();
+            const label = `pdk:${slug}`;
+
+            // Ensure the label exists in the repo (idempotent).
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  ...context.repo,
+                  name: label,
+                  color: 'a855f7',
+                  description: 'PDK this issue belongs to',
+                });
+              } else {
+                throw e;
+              }
+            }
+
+            // Apply the label to the triggering issue. Some events (deleted,
+            // transferred) may leave the issue unreachable — swallow 404s.
+            const issueNumber = context.payload.issue && context.payload.issue.number;
+            if (!issueNumber) {
+              core.info('No issue number on payload — nothing to label.');
+              return;
+            }
+            try {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issueNumber,
+                labels: [label],
+              });
+            } catch (e) {
+              if (e.status === 404 || e.status === 410) {
+                core.info(`Issue unreachable (${e.status}); skipping label apply.`);
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
Adds `.github/workflows/auto-label-pdk.yml`.

On any `issues` event (opened/edited/closed/assigned/labeled/etc.), ensures
a `pdk:<repo-name>` label exists on the repo and applies it to the
triggering issue. Derives the slug from `context.repo.repo.toLowerCase()`
so no per-repo customization is needed.

Why: the modelling-engine + coverage-gap work is tracked in Linear across
28 PDKs. Linear's GitHub sync imports labels — a consistent `pdk:*` tag
makes the cross-repo issue view filterable and groupable.

No behavior change outside of the labelling action. Uses the default
`GITHUB_TOKEN` with `issues: write` permission only.

Ref: internal team memo on `cells_no_model_expected`.

## Summary by Sourcery

Chores:
- Introduce an auto-labeling GitHub Actions workflow that ensures a `pdk:<repo-name>` label exists and is applied to all relevant issue events.