### PR TITLE
feat: add tool.elvis config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ docs = ["autodoc_pydantic", "jupytext", "jupyter-book==1.0.3", "gsim"]
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem"
 
+[tool.elvis]
+connected-layers = [[[11, 0], [12, 0]]]
+short-layers = [[11, 0], [12, 0]]
+
+[tool.elvis.equivalent-ports]
+pad = ["e1", "e2", "e3", "e4", "pad"]
+
 [tool.gdsfactoryplus]
 name = "ubcpdk"
 
@@ -55,14 +62,6 @@ name = "ubcpdk"
 max = 1.6
 min = 1.5
 num = 1000
-
-
-[tool.elvis]
-short-layers = [[11, 0], [12, 0]]
-connected-layers = [[[11, 0], [12, 0]]]
-
-[tool.elvis.equivalent-ports]
-pad = ["e1", "e2", "e3", "e4", "pad"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,14 @@ max = 1.6
 min = 1.5
 num = 1000
 
+
+[tool.elvis]
+short-layers = [[11, 0], [12, 0]]
+connected-layers = [[[11, 0], [12, 0]]]
+
+[tool.elvis.equivalent-ports]
+pad = ["e1", "e2", "e3", "e4", "pad"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true


### PR DESCRIPTION
## Summary
- Add `[tool.elvis]` section to `pyproject.toml` with `short-layers` and `connected-layers` derived from the PDK's tech.py connectivity definitions
- Add `[tool.elvis.equivalent-ports]` for pad cells where applicable

## Test plan
- [x] Verify layer tuples match the PDK's layer definitions
- [x] Verify connected-layers pairs are correct