### PR TITLE
update gdsfactory~=9.43.0 and gplugins~=2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory>=9.39,<9.41",
-  "gplugins[sax,tidy3d]~=2.0.0",
+  "gdsfactory~=9.43.0",
+  "gplugins[sax,tidy3d]~=2.1.0",
   "jsondiff",
   "doroutes~=0.6.0",
   "gdsfactoryplus",


### PR DESCRIPTION
## Summary
- Update `gdsfactory` to `~=9.43.0`
- Update `gplugins` to `~=2.1.0`
- Fix `make test-force` to run `install` first (ensures dev dependencies are available)
- Fix `conftest.py` to auto-accept GDS reference updates when `--force-regen` is passed

## Test plan
- [x] Run `make test-force` locally