### PR TITLE
Add zensical docs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,25 @@ build:
 	pip install build
 	python -m build
 
-docs:
-	uv run python .github/write_components_plot.py
-	uv run python .github/write_components_autodoc.py
-	uv run jb build docs
-
 mask:
 	python ubcpdk/samples/test_masks.py
 
-.PHONY: drc doc docs install
+docs-pdf:
+	uv run python .github/write_components_autodoc.py
+	uv run python .github/write_components_plot.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
+
+docs:
+	uv run python .github/write_components_autodoc.py
+	uv run python .github/write_components_plot.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
+
+docs-serve:
+	uv run python .github/write_components_autodoc.py
+	uv run python .github/write_components_plot.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,26 @@
+site_name: ubcpdk pdk
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+  - Tutorial:
+      - Data Analysis: data_analysis.md
+      - Simulations: simulations.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,14 @@ dev = [
   "pytest-github-actions-annotate-failures",
   "pre-commit"
 ]
-docs = ["autodoc_pydantic", "jupytext", "jupyter-book==1.0.3", "gsim==0.0.16"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
 
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,30 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]},
+  {"Tutorial" = [
+    {"Data Analysis" = "data_analysis.md"},
+    {"Simulations" = "simulations.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "ubcpdk pdk"
+site_url = "https://gdsfactory.github.io/ubc"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation to a Zensical/MkDocs Material setup with HTML and PDF build workflows.

New Features:
- Introduce Zensical/MkDocs-based documentation configuration, including navigation and Material theme settings.
- Add MkDocs PDF configuration to generate a themed PDF version of the documentation.
- Add a documentation post-processing hook to convert MyST-style admonitions to Material-compatible syntax.

Enhancements:
- Update Makefile targets to build, serve, and export documentation using the new Zensical/MkDocs pipeline, including a dedicated PDF target.
- Adjust documentation dependency set to use MkDocs Material, mkdocstrings, and related tools instead of Jupyter Book.