### PR TITLE
fix: remove empty stub pages and tableofcontents directives

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,34 +1,29 @@
 # Table of contents
 # Learn more at https://jterbook.org/customize/toc.html
-
 format: jb-book
 root: index
 parts:
-  - caption: Introduction
-    chapters:
-      - file: tech
-      - file: components
-      - file: components_plot
-      - file: notebooks/00_layout
-      - file: simulations
-        sections:
-          - file: notebooks/meep_ybranch
-          - file: notebooks/11_sparameters
-          - file: notebooks/11_sparameters_gratings
-          - file: notebooks/12_sim_plugins_tidy3d
-          - file: notebooks/13_sim_plugins
-          - file: notebooks/14_sax_tidy3d
-      - file: data_analysis
-        sections:
-          - file: notebooks/31_data_analysis_mzi
-          - file: notebooks/32_data_analysis_ring
-          - file: notebooks/33_data_analysis_dbr
-  - caption: Reference
-    chapters:
-      - file: changelog
-      - url: https://gdsfactory.github.io/gplugins/
-        title: Plugins
-      - url: https://gdsfactory.github.io/gdsfactory
-        title: gdsfactory
-      - url: https://gdsfactory.github.io/gdsfactory-photonics-training/
-        title: gdsfactory-photonics-training
+- caption: Introduction
+  chapters:
+  - file: tech
+  - file: components
+  - file: components_plot
+  - file: notebooks/00_layout
+  - file: notebooks/meep_ybranch
+  - file: notebooks/11_sparameters
+  - file: notebooks/11_sparameters_gratings
+  - file: notebooks/12_sim_plugins_tidy3d
+  - file: notebooks/13_sim_plugins
+  - file: notebooks/14_sax_tidy3d
+  - file: notebooks/31_data_analysis_mzi
+  - file: notebooks/32_data_analysis_ring
+  - file: notebooks/33_data_analysis_dbr
+- caption: Reference
+  chapters:
+  - file: changelog
+  - url: https://gdsfactory.github.io/gplugins/
+    title: Plugins
+  - url: https://gdsfactory.github.io/gdsfactory
+    title: gdsfactory
+  - url: https://gdsfactory.github.io/gdsfactory-photonics-training/
+    title: gdsfactory-photonics-training

--- a/docs/data_analysis.md
+++ b/docs/data_analysis.md
@@ -1,4 +1,0 @@
-# Data Analysis
-
-```{tableofcontents}
-```

--- a/docs/simulations.md
+++ b/docs/simulations.md
@@ -1,4 +1,0 @@
-# Simulations
-
-```{tableofcontents}
-```


### PR DESCRIPTION
## Summary

- Delete `.md` stub files (empty, header-only, or tableofcontents-only)
- Update `_toc.yml` to remove references to deleted files

## Test plan
- [ ] Verify docs build succeeds

## Summary by Sourcery

Clean up documentation by removing unused stub pages and simplifying the table of contents structure.

Documentation:
- Remove empty data_analysis and simulations documentation pages from the docs site.
- Update the book table of contents to drop references to deleted pages and flatten nested sections under the Introduction part.