### PR TITLE
Bump doroutes dependency to ~=1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "gdsfactory~=9.43.0",
   "gplugins[sax,tidy3d]~=2.1.0",
   "jsondiff",
-  "doroutes~=0.6.0",
+  "doroutes~=1.0.0",
   "gdsfactoryplus",
   "pytz"
 ]


### PR DESCRIPTION
## Summary
- Updates doroutes dependency from `~=0.6.0` to `~=1.0.0`
- Closes #544

## Test plan
- [ ] Verify DoRoutes 1.0.0 is published
- [ ] Run PDK tests after updating