### PR TITLE
add update-changelog Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,7 @@ docs-serve:
 	cp CHANGELOG.md docs/changelog.md
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
-.PHONY: drc drc-sample doc docs docs-pdf build
+update-changelog:
+	claude -p "remove links and make a user friendly changelog from @CHANGELOG.md to @docs/changelog.md"
+
+.PHONY: drc drc-sample doc docs docs-pdf build update-changelog


### PR DESCRIPTION
## Summary
- Add `update-changelog` Makefile target that uses Claude to generate a user-friendly changelog from CHANGELOG.md to docs/changelog.md

## Test plan
- [ ] Run `make update-changelog` to verify it works

## Summary by Sourcery

Add a Makefile target to generate a user-friendly docs changelog using Claude and introduce a CLAUDE configuration file.

New Features:
- Add an update-changelog Makefile target to regenerate docs/changelog.md from CHANGELOG.md using Claude.

Enhancements:
- Introduce a CLAUDE.md file linking to AGENTS.md to configure Claude-related behavior.