### PR TITLE
Update CODEOWNERS: remove departed members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @thanojo @Alex-l-r @cdaunt
+* @joamatab @thanojo @cdaunt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt
+* @joamatab @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt
+* @joamatab @thanojo @Alex-l-r @cdaunt


### PR DESCRIPTION
Remove @ThomasPluck, @tvt173, @nikosavola, @sheron-lian, and @Alex-l-r from CODEOWNERS as requested.