### PR TITLE
Add Static/Dynamic tabs to docs layout viewers

### DIFF
--- a/.github/write_components_plot.py
+++ b/.github/write_components_plot.py
@@ -1,10 +1,27 @@
+"""Write components_plot.md with kwasm viewers."""
+
+import base64
 import inspect
+import shutil
+import traceback
 from enum import Enum
+
+import kwasm.embed
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from gdsfactory.serialization import clean_value_json
+
+mpl.use("Agg")
 
 from ubcpdk import PDK
 from ubcpdk.config import PATH
 
+PDK.activate()
+cells = PDK.cells
+
 filepath = PATH.repo / "docs" / "components_plot.md"
+kwasm_dir = PATH.repo / "docs" / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {
     "LIBRARY",
@@ -23,8 +40,48 @@ skip = {
 skip_plot: tuple[str, ...] = ("add_fiber_array_siepic",)
 skip_settings: tuple[str, ...] = ("flatten", "safe_cell_names")
 
-cells = PDK.cells
 
+def _setup_kwasm_viewer() -> None:
+    """Write the shared kwasm viewer HTML (with empty GDS slot)."""
+    if kwasm_dir.exists():
+        shutil.rmtree(kwasm_dir)
+    gds_dir.mkdir(parents=True)
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    (kwasm_dir / "viewer.html").write_text(template)
+
+
+def _write_gds(name: str, kwargs: str) -> bool:
+    """Instantiate cell and write GDS + PNG. Returns True on success."""
+    try:
+        sig = inspect.signature(cells[name])
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cells[name](**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
     f.write(
@@ -62,7 +119,7 @@ Cells
                 kwargs_list.append(f"{p}={enum_class}.{enum_value}")
             # Handle basic types
             elif isinstance(default, int | float | str | tuple):
-                kwargs_list.append(f"{p}={repr(default)}")
+                kwargs_list.append(f"{p}={clean_value_json(default)!r}")
         kwargs = ", ".join(kwargs_list)
 
         # Skip plotting if function has required params or is in skip_plot list
@@ -78,6 +135,8 @@ Cells
 """
             )
         else:
+            has_gds = _write_gds(name, kwargs)
+
             f.write(
                 f"""
 
@@ -86,7 +145,21 @@ Cells
 
 ::: ubcpdk.cells.{name}
 
-```python
+"""
+            )
+
+            if has_gds:
+                f.write('=== "Static"\n\n')
+                f.write(f"    ![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write('=== "Dynamic"\n\n')
+                f.write(
+                    f'    <iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+
+            f.write(
+                f"""```python
 from ubcpdk import PDK, cells
 from ubcpdk.tech import LayerMapUbc
 
@@ -97,3 +170,5 @@ c.plot()
 ```
 """
             )
+
+print(f"Wrote {filepath}")


### PR DESCRIPTION
Fixes #556

## Summary

- Each layout viewer in the generated docs now renders as two tabs: **Static** (PNG image, default) and **Dynamic** (interactive kwasm viewer)
- Adds kwasm infrastructure: `_setup_kwasm_viewer()` creates `docs/kwasm/viewer.html` with the PDK layer properties baked in, and `_write_gds()` generates per-cell GDS + PNG files
- Preserves existing skip/skip_plot/skip_settings logic and Enum handling in kwargs

## Test plan

- [ ] Run `make docs` and verify components page renders with Static/Dynamic tabs
- [ ] Confirm tab switching works between Static and Dynamic views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add kwasm-based dynamic layout viewers alongside static images in the generated components documentation.

New Features:
- Generate a shared kwasm viewer HTML page with baked-in PDK layer properties for interactive layout viewing.
- Emit per-cell GDS and PNG artifacts to support Static (image) and Dynamic (interactive) tabs in docs layout viewers.

Enhancements:
- Normalize default kwarg values using JSON-safe cleaning when rendering example component instantiations in the docs.
- Activate the PDK and centralize cell access at script startup, ensuring consistent context for documentation generation.

Chores:
- Log completion of components_plot.md generation to the console for easier debugging of the docs build script.