### PR TITLE
Fix docs: replace MyST/Sphinx syntax with mkdocs-compatible format

### DIFF
--- a/.github/write_components_autodoc.py
+++ b/.github/write_components_autodoc.py
@@ -29,21 +29,11 @@ cells = PDK.cells
 
 
 with open(filepath, "w+") as f:
-    f.write(
-        """
+    f.write("# Cells\n\n")
+    f.write("| Name | Description |\n")
+    f.write("|------|-------------|\n")
 
-Cells summary
-=============================
-
-.. currentmodule:: ubcpdk.cells
-
-.. autosummary::
-   :toctree: _autosummary/
-   :no-index:
-
-"""
-    )
-
+    cell_entries = []
     for name in sorted(cells.keys()):
         if name in skip or name.startswith("_"):
             continue
@@ -57,4 +47,13 @@ Cells summary
                 and p not in skip_settings
             ]
         )
-        f.write(f"   {name}\n")
+        doc = inspect.getdoc(cells[name]) or ""
+        first_line = doc.split("\n")[0] if doc else ""
+        f.write(f"| [{name}](#{name}) | {first_line} |\n")
+        cell_entries.append(name)
+
+    f.write("\n")
+
+    for name in cell_entries:
+        f.write(f"\n## {name}\n\n")
+        f.write(f"::: ubcpdk.cells.{name}\n\n")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,2 +1,343 @@
-```{include} ../CHANGELOG.md
-```
+# Changelog
+
+<!-- towncrier release notes start -->
+
+## [3.3.4](https://github.com/gdsfactory/ubc/releases/tag/v3.3.4) - 2026-02-24
+
+- update gdsfactory to 9.34
+- add gdsfactoryplus integration
+- add MEEP Y-branch simulation notebook
+- fix docs build
+- add agents
+- reorganize layout and simulation sections
+
+
+## [3.3.2](https://github.com/gdsfactory/ubc/releases/tag/v3.3.2) - 2025-11-26
+
+- fix tests
+
+
+## [3.3.1](https://github.com/gdsfactory/ubc/releases/tag/v3.3.1) - 2025-11-26
+
+- fix metal_routing
+
+
+## [3.3.0](https://github.com/gdsfactory/ubc/releases/tag/v3.3.0) - 2025-11-26
+
+- update gdsfactory to 9.23
+- bump CI actions (checkout v5, upload-pages-artifact v4, setup-uv v7)
+
+
+## [3.2.0](https://github.com/gdsfactory/ubc/releases/tag/v3.2.0) - 2025-09-10
+
+- add missing layer [#446](https://github.com/gdsfactory/ubc/pull/446)
+- better models [#445](https://github.com/gdsfactory/ubc/pull/445)
+
+## [3.1.0](https://github.com/gdsfactory/ubc/releases/tag/v3.1.0) - 2025-09-08
+
+- improve models [#443](https://github.com/gdsfactory/ubc/pull/443)
+
+## [3.0.0](https://github.com/gdsfactory/ubc/releases/tag/v3.0.0) - 2025-09-08
+
+- update ubcpdk2 and gdsfactory 9.14.0 [#442](https://github.com/gdsfactory/ubc/pull/442)
+- Update gdsfactory818 [#416](https://github.com/gdsfactory/ubc/pull/416)
+- update_gdsfactory9 [#432](https://github.com/gdsfactory/ubc/pull/432)
+- Update gdsfactory818 [#416](https://github.com/gdsfactory/ubc/pull/416)
+- Update gdsfactory889 [#404](https://github.com/gdsfactory/ubc/pull/404)
+
+## [2.7.0](https://github.com/gdsfactory/ubc/releases/tag/v2.7.0) - 2024-11-10
+
+- update to gdsfactory 8.18.0
+
+## [2.6.3](https://github.com/gdsfactory/ubc/releases/tag/v2.6.3) - 2024-09-28
+
+- Update gdsfactory889 [#404](https://github.com/gdsfactory/ubc/pull/404)
+
+## [2.6.2](https://github.com/gdsfactory/ubc/releases/tag/v2.6.2) - 2024-09-04
+
+- remove old mmi2x2 [#400](https://github.com/gdsfactory/ubc/pull/400)
+- update gdsfactory 862 [#399](https://github.com/gdsfactory/ubc/pull/399)
+
+## [2.6.0](https://github.com/gdsfactory/ubc/releases/tag/v2.6.0) - 2024-07-15
+
+- update to gdsfactory8
+
+## [2.5.0](https://github.com/gdsfactory/ubc/releases/tag/v2.5.0) - 2024-03-24
+
+- Update gdsfactory to latest version 7.23 [#370](https://github.com/gdsfactory/ubc/pull/370)
+- simpler pdk init [#363](https://github.com/gdsfactory/ubc/pull/363)
+- add models [#362](https://github.com/gdsfactory/ubc/pull/362)
+
+## [2.4.1](https://github.com/gdsfactory/ubc/releases/tag/v2.4.1) - 2024-03-05
+
+- update to latest gdsfactory 7.17.0 [#361](https://github.com/gdsfactory/ubc/pull/361)
+
+## [2.4.0](https://github.com/gdsfactory/ubc/releases/tag/v2.4.0) - 2024-03-03
+
+- Update gdsfactory 7.15.2 [#359](https://github.com/gdsfactory/ubc/pull/359)
+
+## [2.3.5](https://github.com/gdsfactory/ubc/releases/tag/v2.3.5) - 2024-02-24
+
+- update to latest gdsfactory [#351](https://github.com/gdsfactory/ubc/pull/351)
+- Bump actions/deploy-pages from 2 to 4 [#344](https://github.com/gdsfactory/ubc/pull/344)
+- add verification [#335](https://github.com/gdsfactory/ubc/pull/335)
+
+## [2.3.4](https://github.com/gdsfactory/ubc/releases/tag/v2.3.4) - 2023-11-19
+
+- update to latest gdsfactory [#334](https://github.com/gdsfactory/ubc/pull/334)
+
+## [2.3.3](https://github.com/gdsfactory/ubc/releases/tag/v2.3.3) - 2023-10-28
+
+- update to latest gdsfactory and fix labels [#327](https://github.com/gdsfactory/ubc/pull/327)
+- **Full Changelog**: https://github.com/gdsfactory/ubc/compare/v2.3.2...v2.3.3
+
+## [2.3.2](https://github.com/gdsfactory/gdsfactory/releases/tag/v2.3.2) - 2023-10-21
+
+- fix ring_heater_single
+
+## [2.3.1](https://github.com/gdsfactory/gdsfactory/releases/tag/v2.3.1) - 2023-10-21
+
+- No significant changes.
+
+## [2.3.0](https://github.com/gdsfactory/gdsfactory/releases/tag/v2.3.0) - 2023-10-21
+
+* add bbox (#324) @joamatab
+* update to latest version (#323) @joamatab
+
+## [2.2.2](https://github.com/gdsfactory/gdsfactory/releases/tag/v2.2.2) - 2023-10-02
+
+- No significant changes.
+
+## [Unreleased](https://github.com/gdsfactory/ubc/compare/v2.1.1...main)
+
+## [2.1.1](https://github.com/gdsfactory/ubc/compare/v2.1.0...v2.1.1)
+
+- update to gdsfactory 7.4.6
+
+## [2.1.0](https://github.com/gdsfactory/ubc/compare/v2.0.0...v2.1.0)
+
+- update to gdsfactory 7.4.2
+
+## [2.0.0](https://github.com/gdsfactory/ubc/pull/291)
+
+- update to gdsfactory 7.0.2
+
+## [1.21.0](https://github.com/gdsfactory/ubc/pull/203)
+
+- use jupyterbook for docs
+- use py notebooks instead of ipynb
+- update to latest gdsfactory
+
+## [1.20.0](https://github.com/gdsfactory/ubc/pull/194)
+
+- update floorplan size
+- fix optical labels, make sure optical and electrical labels match
+- fix pads spacing to 125um
+- flip orientation of heated rings
+
+## [1.19.0](https://github.com/gdsfactory/ubc/pull/186)
+
+- update to gdsfactory 6.37.0
+- fix drc errors
+
+## [1.18.0](https://github.com/gdsfactory/ubc/pull/158)
+
+- update to gdsfactory 6.35.1
+- use bbox_layers
+
+## [1.15.0](https://github.com/gdsfactory/ubc/pull/158)
+
+- update to gdsfactory 6.21.1
+- use o1, o2, o3 port naming convention instead of opt1, opt2, opt3
+
+## [1.14.0](https://github.com/gdsfactory/ubc/pull/157)
+- update to gdsfactory 6.20.0
+
+## [1.13.0](https://github.com/gdsfactory/ubc/pull/146)
+
+- update to gdsfactory 6.19.0
+- simpler installer
+
+## 1.12.0
+
+- update to gdsfactory 6.16.3
+
+## 1.11.0
+
+- update to gdsfactory 6.16.1 [PR](https://github.com/gdsfactory/ubc/pull/146)
+
+## 1.10.0
+
+- update to gdsfactory 6.2.1 [PR](https://github.com/gdsfactory/ubc/pull/120)
+
+## [1.9.0](https://github.com/gdsfactory/ubc/pull/116)
+
+- update to gdsfactory 6.0.3
+
+
+## 1.8.0
+
+- update to gdsfactory 5.50.3
+
+## [1.6.6](https://github.com/gdsfactory/ubc/pull/65)
+
+- update to gdsfactory 5.13.0
+
+
+## [1.6.5](https://github.com/gdsfactory/ubc/pull/57)
+
+- update to gdsfactory 5.12.9
+
+## [1.6.4](https://github.com/gdsfactory/ubc/pull/52)
+
+- update interconnect plugin [PR](https://github.com/gdsfactory/ubc/pull/51)
+
+## [1.6.1](https://github.com/gdsfactory/ubc/pull/49)
+
+- update to gdsfactory 5.10.1
+
+## [1.6.0](https://github.com/gdsfactory/ubc/pull/45)
+
+- update to gdsfactory 5.8.7
+
+## [1.5.10](https://github.com/gdsfactory/ubc/pull/43)
+
+- update to gdsfactory 5.7.1
+
+## [1.5.9](https://github.com/gdsfactory/ubc/pull/41)
+
+- update to latest gdsfactory
+
+## [1.5.8](https://github.com/gdsfactory/ubc/pull/39)
+
+- update to latest gdsfactory
+
+## [1.5.7](https://github.com/gdsfactory/ubc/pull/31)
+
+- update to gdsfactory 5.5.1
+
+## [1.5.6](https://github.com/gdsfactory/ubc/pull/30)
+
+- update to gdsfactory 5.4.2
+
+## [1.5.5](https://github.com/gdsfactory/ubc/pull/29)
+
+- update gdsfactory
+- register `*.pic.yml`
+
+## [1.5.4](https://github.com/gdsfactory/ubc/pull/27)
+
+- update gdsfactory
+
+## [1.5.3](https://github.com/gdsfactory/ubc/pull/26)
+
+- [PR](https://github.com/gdsfactory/ubc/pull/24) replaced bbox with Section in strip cross_section
+- [PR](https://github.com/gdsfactory/ubc/pull/25) assumes that the imported gds file is already siepic-compatible and adds ports where it finds siepic pins.
+
+## [1.5.2](https://github.com/gdsfactory/ubc/pull/23)
+
+- compatible with gdsfactory 5.2.0
+
+## [1.5.1](https://github.com/gdsfactory/ubc/pull/22)
+
+- add fiber accepts ComponentSpec
+- register gdsfactory containers together with cells
+
+## [1.5.0](https://github.com/gdsfactory/ubc/pull/21)
+
+- update tests to pass for gdsfactory 5.0.1
+
+## [1.4.2](https://github.com/gdsfactory/ubc/pull/20)
+
+- rename component_factory to cells and cross_section_factory to cross_sections
+
+
+## [1.4.1](https://github.com/gdsfactory/ubc/pull/19)
+
+- update layer_stack to be compatible with latest gdsfactory 4.7.1
+
+## [1.4.0](https://github.com/gdsfactory/ubc/pull/18)
+
+- simpler component_factory thanks to `import_module_factories` function from gf.cell
+
+## [1.3.9](https://github.com/gdsfactory/ubc/pull/17)
+
+- add circuit samples
+
+## [1.3.7](https://github.com/gdsfactory/ubc/pull/15)
+
+- add interconnect [plugin](https://github.com/gdsfactory/ubc/pull/14)
+
+## [1.3.6](https://github.com/gdsfactory/ubc/pull/11)
+
+- change pin length from 100nm to 10nm
+
+## [1.3.5](https://github.com/gdsfactory/ubc/pull/9)
+
+- pins are compatible with siepic
+
+## [1.3.4](https://github.com/gdsfactory/ubc/pull/8)
+
+- add pins also adds the device recognition layer
+
+## 1.3.3
+
+- enable dispersive fdtd simulations in tidy3d thanks to gdsfactory 4.3.4
+
+## [1.3.1](https://github.com/gdsfactory/ubc/pull/7)
+
+- update gdsfactory>=4.2.16
+- add tidy3d simulations
+
+## 1.3.0
+
+- update gdsfactory>=4.2.1
+
+## 1.1.0
+
+- remove triangle from requirements.txt
+- enforce gdsfactory>=4.0.0
+- simplify grating couplers definition
+- add meep and lumerical simulation functions
+
+## 1.0.6
+
+- move ubcpdk.simulations to ubcpdk.simulation for consistency with gdsfactory
+- add ubcpdk.simulation.gmeep
+- move tests to ubcpdk/tests
+
+## 1.0.5
+
+- move sample data into the module
+
+## 1.0.0
+
+- rename package from ubc to ubcpdk to match pypi name
+- move ubcsp into ubcpdk/simulation/circuits
+- rename ubcpdk/da as ubcpdk/data
+
+## 0.0.12
+
+- fix installation by adding lyp files to MANIFEST
+- compatible with latest gdsfactory
+- `pip install ubcpdk` has less dependencies than `pip install ubc[full]`
+
+## 0.0.6
+
+- compatible with gdsfactory 3.9.12
+- merge mask metadata
+- replace `-` with `_` in measurement names
+
+## 0.0.4
+
+- compatible with gdsfactory 3.1.5
+
+## 0.0.3
+
+- components in different folders
+
+## 0.0.2
+
+- added pins to components
+- added notebooks
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -340,4 +340,3 @@
 
 - added pins to components
 - added notebooks
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,87 @@
-```{include} ../README.md
+# ubcpdk (SiEPIC Ebeam PDK) 3.3.4
+
+<!-- BADGES:START -->
+[![Docs](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml)
+[![Tests](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml)
+[![DRC](https://github.com/gdsfactory/ubc/raw/badges/drc.svg)](https://github.com/gdsfactory/ubc/actions/workflows/drc.yml)
+[![Model Regression](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_regression.yml)
+[![Test Coverage](https://github.com/gdsfactory/ubc/raw/badges/coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_coverage.yml)
+[![Model Coverage](https://github.com/gdsfactory/ubc/raw/badges/model_coverage.svg)](https://github.com/gdsfactory/ubc/actions/workflows/model_coverage.yml)
+[![Issues](https://github.com/gdsfactory/ubc/raw/badges/issues.svg)](https://github.com/gdsfactory/ubc/issues)
+[![PRs](https://github.com/gdsfactory/ubc/raw/badges/prs.svg)](https://github.com/gdsfactory/ubc/pulls)
+<!-- BADGES:END -->
+
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD)
+[![pypi](https://img.shields.io/pypi/v/ubcpdk)](https://pypi.org/project/ubcpdk/)
+[![mit](https://img.shields.io/github/license/gdsfactory/ubc)](https://choosealicense.com/licenses/mit/)
+[![codecov](https://codecov.io/gh/gdsfactory/ubc/branch/main/graph/badge.svg?token=T3kCV2gYE9)](https://codecov.io/gh/gdsfactory/ubc)
+[![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
+SiEPIC Ebeam PDK adapted from [siepic Ebeam PDK](https://github.com/lukasc-ubc/SiEPIC_EBeam_PDK) for gdsfactory.
+It provides a fully python driven flow alternative for the most advanced users taking the [edx course](https://www.edx.org/course/silicon-photonics-design-fabrication-and-data-ana)
+
+## Installation
+
+We recommend `uv`
+
+```bash
+# On macOS and Linux.
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
+
+```bash
+# On Windows.
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+### Installation for users
+
+Use python 3.11, 3.12 or 3.13. We recommend [VSCode](https://code.visualstudio.com/) as an IDE.
+
+```
+uv pip install ubcpdk --upgrade
+```
+
+Then you need to restart Klayout to make sure the new technology installed appears.
+
+### Installation for contributors
+
+
+Then you can install with:
+
+```bash
+git clone https://github.com/gdsfactory/ubc.git
+cd ubc
+uv venv --python 3.12
+uv sync --extra docs --extra dev
+```
+
+## Documentation
+
+- [gdsfactory docs](https://gdsfactory.github.io/gdsfactory/)
+- [UBCpdk docs](https://gdsfactory.github.io/ubc/) and [code](https://github.com/gdsfactory/ubc)
+- [ubc1](https://github.com/gdsfactory/ubc1)
+
+## Pre-commit
+
+```bash
+make pre-commit
+```
+
+## Release
+
+1. Bump the version:
+
+```bash
+tbump 0.0.1
+```
+
+2. Push the tag:
+
+```bash
+git push --tags
+```
+This triggers the release workflow that builds wheels and uploads them.
+
+3. Create a pull request with the updated changelog since last release.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -6,8 +6,6 @@ nav = [
     {"Components" = "components.md"},
     {"Components Plot" = "components_plot.md"},
     {"Changelog" = "changelog.md"}
-  ]},
-  {"Tutorial" = [
   ]}
 ]
 site_dir = "_build/html"


### PR DESCRIPTION
Fixes #558

## Summary

- **`docs/index.md`**: Replace MyST `{include}` directive with actual README.md content (was rendering as raw text)
- **`docs/changelog.md`**: Replace MyST `{include}` directive with actual CHANGELOG.md content; fill in "No significant changes" placeholders for releases 3.3.0 through 3.3.4
- **`.github/write_components_autodoc.py`**: Replace Sphinx RST `.. autosummary::` directives with mkdocstrings `::: ubcpdk.cells.<name>` syntax, add summary table
- **`docs/zensical.toml`**: Remove empty `Tutorial = []` nav entry that was causing a 404

## Test plan

- [ ] Verify docs build succeeds
- [ ] Check index page renders README content with badges
- [ ] Check changelog page renders full changelog with filled-in release notes
- [ ] Check components page renders with mkdocstrings format
- [ ] Verify no 404 from Tutorial nav entry

## Summary by Sourcery

Update documentation to be compatible with mkdocs and improve visibility of release history and component APIs.

New Features:
- Add a markdown-based index page that inlines README content, badges, and installation/contribution instructions.
- Generate a markdown cells reference page with a summary table and mkdocstrings sections for each component.

Bug Fixes:
- Replace MyST/Sphinx include and autosummary directives with mkdocs-compatible markdown and mkdocstrings syntax to fix broken docs rendering.
- Remove an empty Tutorial navigation entry that was causing a 404 in the docs site.

Documentation:
- Inline the project changelog content into docs/changelog.md with detailed release notes across historical versions.