### PR TITLE
Add --verbose flag to twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           make build
-          twine upload dist/*
+          twine upload --verbose dist/*
   release_github:
     needs: release_pypi
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
## Summary
- Adds --verbose flag to twine upload commands in the release workflow for better upload diagnostics.

Closes #561

## Test plan
- [ ] Trigger a release workflow run and verify twine outputs verbose logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Enable verbose output for twine upload in the release GitHub Actions workflow.