### PR TITLE
fix: correct pre-commit instructions and add tests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
-Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow-public](https://github.com/doplaydo/pdk-ci-workflow-public). `make dev` fetches the canonical config and installs the git hook.
 
 ```bash
 make dev

--- a/README.md
+++ b/README.md
@@ -65,8 +65,18 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+
 ```bash
-make pre-commit
+make dev
+```
+
+## Tests
+
+Run the test suite:
+
+```bash
+make test
 ```
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ubcpdk (SiEPIC Ebeam PDK) 3.3.4
 
+The University of British Columbia's SiEPIC EBeam PDK is a 220nm SOI silicon photonics platform fabricated via electron-beam lithography, widely used in academia and multi-project-wafer runs.
+
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/ubc/actions/workflows/test_code.yml)


### PR DESCRIPTION
The Makefile's pre-commit setup target is `dev` (fetches the canonical config from pdk-ci-workflow), not `make pre-commit`. This updates the README to match, and adds a missing `## Tests` section documenting `make test`.

Part of doplaydo/pdks#49.

## Summary by Sourcery

Document pre-commit setup via `make dev` and add a tests section describing `make test` usage in the README.

Documentation:
- Clarify centralized pre-commit hook configuration and setup via `make dev` in the README.
- Add a README tests section documenting how to run the test suite with `make test`.