### PR TITLE
chore: add @MarkCunningham0410 to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @thanojo @cdaunt
+* @joamatab @thanojo @cdaunt @MarkCunningham0410


### PR DESCRIPTION
Adds @MarkCunningham0410 as codeowner across all files.

## Summary by Sourcery

Chores:
- Add @MarkCunningham0410 as the default CODEOWNER for all files in the repository.