### PR TITLE
fix: add markdown extensions for PDF tab rendering

### DIFF
--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -8,6 +8,11 @@ nav:
       - Components Plot: components_plot.md
       - Changelog: changelog.md
   - Tutorial:
+markdown_extensions:
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.superfences
+  - admonition
 plugins:
   - search
   - autorefs


### PR DESCRIPTION
## Summary

Add `pymdownx.tabbed`, `pymdownx.superfences`, and `admonition` markdown extensions to `mkdocs-pdf.yml` so content tabs and warning blocks render correctly in the release PDF.

Without these extensions, the PDF shows literal tab syntax and raw admonition markup instead of rendered content.

Same fix as doplaydo/tps45#296.

## Changes

- `mkdocs-pdf.yml`: Add `markdown_extensions` section

## Test plan

- [ ] Verify `mkdocs build -f mkdocs-pdf.yml` succeeds

Closes #573

## Summary by Sourcery

Update MkDocs PDF configuration to support proper rendering of tabs and admonitions in generated documentation PDFs.

Enhancements:
- Enable pymdownx.tabbed, pymdownx.superfences, and admonition markdown extensions in the MkDocs PDF configuration to improve PDF rendering of tabbed content and callout blocks.

Build:
- Adjust mkdocs-pdf.yml build configuration to include required markdown extensions for PDF generation.