### PR TITLE
test: check all ports have manhattan orientations

### DIFF
--- a/tests/test_si220_cband.py
+++ b/tests/test_si220_cband.py
@@ -219,6 +219,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "coupler_symmetric"
     c = cells[component_type]()


### PR DESCRIPTION
Closes #580

Adds `test_port_orientations_manhattan` to `tests/test_si220_cband.py`, parametrized over every PDK cell (`cell_names`), asserting that each port's orientation is 0, 90, 180 or 270 degrees. `gf.ComponentAllAngle` components are skipped, and a `skip_test_manhattan_ports` set is available for known issues (currently empty). It is parametrized over the repo-wide `cell_names` rather than `optical_port_cell_names`, since that narrower list excludes cells for reasons specific to the port-*position* check and says nothing about orientations.

This is a templated rollout of the same test we are adding across our PDKs; the reference change was reviewed and approved by @joamatab.

⚠️ AI-created PR: a human must review the actual code changes before merge.

## Test plan

- [ ] CI passes

## Summary by Sourcery

Tests:
- Add a parametrized test over all PDK cells to assert that port orientations are restricted to 0°, 90°, 180° or 270°, skipping all-angle components and an explicit skip list.