### PR TITLE
docs: document missing arguments in cells and simulation circuits

### DIFF
--- a/ubcpdk/cells/containers.py
+++ b/ubcpdk/cells/containers.py
@@ -109,6 +109,9 @@ def add_fiber_array(
         cross_section: spec.
         straight: straight component.
         taper: taper component.
+        mirror_grating_coupler: True mirrors the grating coupler before
+            connecting it to the routes.
+        gc_rotation: grating coupler rotation in degrees.
         kwargs: cross_section settings.
 
     """
@@ -237,6 +240,7 @@ def add_pads(
     Args:
         component: to add fiber array and pads.
         username: for the label.
+        label_port_name: electrical port name where the label is placed.
         kwargs: for add_fiber_array.
     """
     c0 = gf.get_component(component).copy()

--- a/ubcpdk/cells/die_with_pads.py
+++ b/ubcpdk/cells/die_with_pads.py
@@ -78,11 +78,10 @@ def pad(
     Args:
         size: x, y size.
         layer: pad layer.
-        bbox_layers: list of layers.
-        bbox_offsets: Optional offsets for each layer with respect to size.
-            positive grows, negative shrinks the size.
         port_inclusion: from edge.
         port_orientation: in degrees.
+        port_orientations: list of port orientations in degrees to add on the
+            edges. None adds no edge ports.
     """
     return gf.components.pad(
         size=size,

--- a/ubcpdk/simulation/circuits/mzi_spectrum.py
+++ b/ubcpdk/simulation/circuits/mzi_spectrum.py
@@ -22,10 +22,17 @@ def mzi_spectrum(
     """Returns MZI spectrum.
 
     Args:
-        L1_um.
-        L2_um.
-        wavelength_um.
-        beta: propagation constant.
+        L1_um: length of the first MZI arm in um.
+        L2_um: length of the second MZI arm in um.
+        wavelength_um: wavelength or array of wavelengths in um.
+        beta: propagation constant. Array or callable taking
+            (wavelength_um, neff, alpha, n1, n2, n3).
+        alpha: propagation loss [micron^-1] constant.
+        neff: effective index. Float or callable taking
+            (wavelength_um, n1, n2, n3) and returning the effective index.
+        n1: effective index at the reference wavelength (1.55 um).
+        n2: first order dispersion term [1/um] of the neff expansion.
+        n3: second order dispersion term [1/um^2] of the neff expansion.
     """
     if callable(beta):
         beta = beta(wavelength_um, neff=neff, alpha=alpha, n1=n1, n2=n2, n3=n3)

--- a/ubcpdk/simulation/circuits/waveguide.py
+++ b/ubcpdk/simulation/circuits/waveguide.py
@@ -31,6 +31,11 @@ def beta(wavelength_um=wavelength_um, alpha=1e-3, neff=neff, n1=2.4, n2=-1, n3=0
     Args:
         wavelength_um: in um.
         alpha: propagation loss [micron^-1] constant.
+        neff: effective index. Float or callable taking
+            (wavelength_um, n1, n2, n3) and returning the effective index.
+        n1: effective index at the reference wavelength (1.55 um).
+        n2: first order dispersion term [1/um] of the neff expansion.
+        n3: second order dispersion term [1/um^2] of the neff expansion.
     """
     if callable(neff):
         neff = neff(wavelength_um, n1=n1, n2=n2, n3=n3)


### PR DESCRIPTION
Closes #582

The shared pre-commit config now runs `pydocstyle --select=D417`, which requires every positional and keyword-only argument to have an entry in the docstring `Args:` / `Parameters` section.

Documented the flagged arguments across five functions:

- `add_fiber_array`: `gc_rotation`, `mirror_grating_coupler`
- `add_pads`: `label_port_name`
- `pad`: `port_orientations` — and dropped the stale `bbox_layers` / `bbox_offsets` entries, which are hardcoded in the body rather than accepted as parameters
- `mzi_spectrum`: `L1_um`, `L2_um`, `wavelength_um`, `alpha`, `neff`, `n1`, `n2`, `n3` (the first three had names but no descriptions, so they did not count as documented)
- `beta`: `neff`, `n1`, `n2`, `n3`

The `n1`/`n2`/`n3` descriptions follow `neff()` in `waveguide.py`, which evaluates `n1 + n2*(w - w0) + n3*(w - w0)**2` around `w0 = 1.55` um.

Docstrings only; no behavior change.

## Test plan
- [ ] CI pre-commit job passes

---
Requested by @joamatab. Opened from a fork — I do not have push access to this repo. AI-authored: please review the wording of the new argument descriptions before merging.

## Summary by Sourcery

Document all previously missing function arguments and align pad documentation with the current API without changing runtime behavior.

Enhancements:
- Complete docstrings for missing function arguments across fiber-array, pad, and simulation circuit APIs, including wavelength and effective-index parameters.
- Remove stale pad docstring entries for parameters that are not accepted by the function.

Documentation:
- Clarify propagation constant, dispersion, effective-index, and grating-coupler argument descriptions to satisfy documentation style checks.