### PR TITLE
ci: refresh Generate nyanlib caller from the centralized template

### DIFF
--- a/.github/workflows/generate_nyanlib.yml
+++ b/.github/workflows/generate_nyanlib.yml
@@ -9,3 +9,5 @@ jobs:
     uses: doplaydo/pdk-ci-workflow-public/.github/workflows/generate_nyanlib.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      GFP_GHCR_APP_ID: ${{ secrets.GFP_GHCR_APP_ID }}
+      GFP_GHCR_APP_PRIVATE_KEY: ${{ secrets.GFP_GHCR_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The centralized reusable `generate_nyanlib` workflow now authenticates to GHCR with a GitHub App token rather than the job's `GITHUB_TOKEN`, so it needs `GFP_GHCR_APP_ID` and `GFP_GHCR_APP_PRIVATE_KEY` forwarded from the caller.

Refreshed straight from `doplaydo/pdk-ci-workflow-public/templates`, no manual edits:

- updated `.github/workflows/generate_nyanlib.yml`

`pre-commit run --all-files` run twice.

## Test plan
- [ ] CI pre-commit job passes
- [ ] `Generate nyanlib` can pull the `gfp-server` image

Closes #589

## Summary by Sourcery

Update the Generate nyanlib workflow to support authenticated GHCR image pulls using the centralized workflow requirements.

Enhancements:
- Pass GitHub App credentials through the Generate nyanlib workflow caller for GHCR authentication.

CI:
- Refresh the Generate nyanlib workflow configuration to match the centralized reusable template.