### PR TITLE
Remove doroutes dependency and A* routing strategies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "gdsfactory~=9.45.0",
   "gplugins[sax,tidy3d]~=2.1.0",
   "jsondiff",
-  "doroutes~=1.1.0",
   "gdsfactoryplus",
   "pytz"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
 ]
 docs = [
   "jupyter",
+  "kwasm",
   "mkdocs-material",
   "mkdocs-with-pdf",
   "nbconvert",

--- a/ubcpdk/tech.py
+++ b/ubcpdk/tech.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 from functools import partial
 
 import gdsfactory as gf
-from doroutes.bundles import add_bundle_astar
 from gdsfactory.add_pins import add_pin_path
 from gdsfactory.component import Component
 from gdsfactory.cross_section import get_cross_sections
@@ -363,32 +362,12 @@ route_bundle_metal_corner = partial(
     port_type="electrical",
 )
 
-route_astar = partial(
-    add_bundle_astar,
-    layers=["WG"],
-    bend="bend_euler",
-    straight="straight",
-    grid_unit=500,
-    spacing=3,
-)
-
-route_astar_metal = partial(
-    add_bundle_astar,
-    layers=["M2_ROUTER"],
-    bend="wire_corner",
-    straight="straight_metal",
-    grid_unit=500,
-    spacing=15,
-)
-
 
 routing_strategies = dict(
     route_bundle=route_bundle,
     route_bundle_rib=route_bundle_rib,
     route_bundle_metal=route_bundle_metal,
     route_bundle_metal_corner=route_bundle_metal_corner,
-    route_astar=route_astar,
-    route_astar_metal=route_astar_metal,
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -603,23 +603,6 @@ wheels = [
 ]
 
 [[package]]
-name = "doroutes"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "kfactory" },
-    { name = "kwasm" },
-    { name = "numpy" },
-    { name = "shapely" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/88/91f559c1e1fc1d1f7e30136bcacdcc22f83ae2c0ed9b5c06c4d5790b43d0/doroutes-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ec6168f0b57bb4a7dd8b1d4581fd371873b3921f86037fe03c6a6af7839457c2", size = 3325645, upload-time = "2026-06-04T10:06:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/4e/6c0acffd204b131ee45d3f368b45fdc5093d35aa8c6275af2e49a8aad630/doroutes-1.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1283de66b403a07930384cfa12890313d51c79b510303b6845d75497ee4f21c2", size = 3487225, upload-time = "2026-06-04T10:06:13.734Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/05/fb812f7bb1cd3e291f1e20a03dd5075be19023a51779cc7fda6a135aed77/doroutes-1.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c564ba2c1a71d83636df5dbdb55bab1daad02c250d095ea41f18c96ced2d0c1b", size = 3660432, upload-time = "2026-06-04T10:06:15.292Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/c7/ba66b740b953bddf08eab076acecd803b8a6f8910a458e3177edfb29e804/doroutes-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:fde94a996aff6804822a4ef4ba9f1832bf8c5bd8b87134fa16ed19f12ba2847a", size = 3045451, upload-time = "2026-06-04T10:06:16.51Z" },
-]
-
-[[package]]
 name = "elvis-lvs"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1659,17 +1642,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/43/59c8680bce1005bb0247d4d4291d1862f62ac12e1bca984f22920b97996d/klujax-0.5.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea9668b52e6791345796470fba4a903113d2eef19ca03b58aaa54e76444522c5", size = 2915350, upload-time = "2026-04-15T18:52:09.238Z" },
     { url = "https://files.pythonhosted.org/packages/5f/26/48ed386475225905033f293ad67c48ccb83368b23192a0dc9f6272cdb59a/klujax-0.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fd2b664224a9f5935a4961d978ec9b40fc92fb35e78113ec0e8026be95132efe", size = 184786, upload-time = "2026-04-15T18:52:10.689Z" },
     { url = "https://files.pythonhosted.org/packages/07/02/f232f8801c9aaa069c3ae5e56e66222561a6e9fd38a627fb0c5a792dc22b/klujax-0.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f4198d9973958246c9c8282004ee4053f36af3a000b9d7960b9aeb705362ee4a", size = 155148, upload-time = "2026-04-15T18:52:11.965Z" },
-]
-
-[[package]]
-name = "kwasm"
-version = "0.2.26"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/a9/96f5b9f3ad75a4f9d3b2e36b64df013c1105729890e7c15f3d8810636f09/kwasm-0.2.26-py3-none-any.whl", hash = "sha256:c07af2bbf27335777ad604041c4c78752bf07c21c77a685a26c0de098dc47e4a", size = 6938612, upload-time = "2026-08-20T15:42:23.961Z" },
 ]
 
 [[package]]
@@ -3608,7 +3580,6 @@ name = "ubcpdk"
 version = "3.3.5"
 source = { editable = "." }
 dependencies = [
-    { name = "doroutes" },
     { name = "gdsfactory" },
     { name = "gdsfactoryplus" },
     { name = "gplugins", extra = ["sax", "tidy3d"] },
@@ -3636,7 +3607,6 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "doroutes", specifier = "~=1.1.0" },
     { name = "gdsfactory", specifier = "~=9.45.0" },
     { name = "gdsfactoryplus" },
     { name = "gdsfactoryplus", marker = "extra == 'dev'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1645,6 +1645,17 @@ wheels = [
 ]
 
 [[package]]
+name = "kwasm"
+version = "0.2.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/a9/96f5b9f3ad75a4f9d3b2e36b64df013c1105729890e7c15f3d8810636f09/kwasm-0.2.26-py3-none-any.whl", hash = "sha256:c07af2bbf27335777ad604041c4c78752bf07c21c77a685a26c0de098dc47e4a", size = 6938612, upload-time = "2026-08-20T15:42:23.961Z" },
+]
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3598,6 +3609,7 @@ dev = [
 ]
 docs = [
     { name = "jupyter" },
+    { name = "kwasm" },
     { name = "mkdocs-material" },
     { name = "mkdocs-with-pdf" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -3613,6 +3625,7 @@ requires-dist = [
     { name = "gplugins", extras = ["sax", "tidy3d"], specifier = "~=2.1.0" },
     { name = "jsondiff" },
     { name = "jupyter", marker = "extra == 'docs'" },
+    { name = "kwasm", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mkdocs-with-pdf", marker = "extra == 'docs'" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },


### PR DESCRIPTION
Closes #591

Removes the `doroutes` dependency and the A* routing strategies it provided.

**What changed**

- `pyproject.toml`: dropped the `doroutes` requirement
- `tech.py`: removed the `add_bundle_astar` import, the `partial(...)` strategy
  definitions, and their entries in `routing_strategies`
- `uv.lock`: regenerated with `uv lock`

**Breaking change.** The A* strategy names are gone from `routing_strategies` with
no replacement, per the request. I checked the repo for anything referencing them —
Python, notebooks, and `.pic.yml` schematics — and found nothing outside the files
changed here.

Opened from a fork; I don't have push access here.

> [!WARNING]
> AI-created PR. A human must review the actual code changes before merge.

Requested by @joamatab

## Summary by Sourcery

Remove doroutes and its A* routing strategies from the project.

Enhancements:
- Remove the deprecated A* routing strategies from the technology configuration.

Build:
- Remove the doroutes runtime dependency and add kwasm to the documentation dependencies; regenerate the dependency lockfile.